### PR TITLE
New Rule Proj0001: .NET project file could not be located

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,0 +1,19 @@
+name: Build & Test
+
+on: [push]
+
+jobs:
+  build:
+ 
+    runs-on: ubuntu-latest
+ 
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET 7.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '7.0.x'
+    - name: Build with dotnet
+      run: dotnet build --configuration Release
+    - name: Run unit tests
+      run: dotnet test --no-build --configuration Release

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Contains [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 that report issues on .NET project files.
 
 ## Rules
-* 
+* [**Proj0001** .NET project file could not be located](rules/Proj0001.md)

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -24,9 +24,16 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj0001.md = rules\Proj0001.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompliantCSharp", "projects\CompliantCSharp\CompliantCSharp.csproj", "{1A2C9D4D-2E3C-4726-ABC9-C77B41AE1DA9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CompliantCSharp", "projects\CompliantCSharp\CompliantCSharp.csproj", "{1A2C9D4D-2E3C-4726-ABC9-C77B41AE1DA9}"
 EndProject
-Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "CompliantVB", "projects\CompliantVB\CompliantVB.vbproj", "{74F59396-7A67-474A-A404-97B038C237F3}"
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "CompliantVB", "projects\CompliantVB\CompliantVB.vbproj", "{74F59396-7A67-474A-A404-97B038C237F3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{1BF2B41D-E15B-4E95-AAE0-9B33B4A1523E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{E6209CFA-DDCD-497E-8B85-804B58B8FAEC}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build-test.yaml = .github\workflows\build-test.yaml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +64,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{1A2C9D4D-2E3C-4726-ABC9-C77B41AE1DA9} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{74F59396-7A67-474A-A404-97B038C237F3} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{1BF2B41D-E15B-4E95-AAE0-9B33B4A1523E} = {BED71055-3C56-4C5B-9D83-A7B2CCD3B8CA}
+		{E6209CFA-DDCD-497E-8B85-804B58B8FAEC} = {1BF2B41D-E15B-4E95-AAE0-9B33B4A1523E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -35,6 +35,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build-test.yaml = .github\workflows\build-test.yaml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NoAdditionalFiles", "projects\NoAdditionalFiles\NoAdditionalFiles.csproj", "{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{74F59396-7A67-474A-A404-97B038C237F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74F59396-7A67-474A-A404-97B038C237F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74F59396-7A67-474A-A404-97B038C237F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,6 +72,7 @@ Global
 		{74F59396-7A67-474A-A404-97B038C237F3} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{1BF2B41D-E15B-4E95-AAE0-9B33B4A1523E} = {BED71055-3C56-4C5B-9D83-A7B2CCD3B8CA}
 		{E6209CFA-DDCD-497E-8B85-804B58B8FAEC} = {1BF2B41D-E15B-4E95-AAE0-9B33B4A1523E}
+		{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -1,0 +1,64 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33815.320
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetProjectFile.Analyzers", "src\DotNetProjectFile.Analyzers\DotNetProjectFile.Analyzers.csproj", "{EB081E61-BCAB-40B8-9358-A5914F223F37}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetProjectFile.Analyzers.Specs", "specs\DotNetProjectFile.Analyzers.Specs\DotNetProjectFile.Analyzers.Specs.csproj", "{626C7F5F-15EA-42AA-B4F8-5BD2A86B8FE6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BED71055-3C56-4C5B-9D83-A7B2CCD3B8CA}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
+		LICENSE.md = LICENSE.md
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projects", "Projects", "{46AE4B0F-B941-4E9F-B307-7D7D1E168F64}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3-2049-4539-8A37-D370EE0F91F7}"
+	ProjectSection(SolutionItems) = preProject
+		rules\Proj0001.md = rules\Proj0001.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompliantCSharp", "projects\CompliantCSharp\CompliantCSharp.csproj", "{1A2C9D4D-2E3C-4726-ABC9-C77B41AE1DA9}"
+EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "CompliantVB", "projects\CompliantVB\CompliantVB.vbproj", "{74F59396-7A67-474A-A404-97B038C237F3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EB081E61-BCAB-40B8-9358-A5914F223F37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB081E61-BCAB-40B8-9358-A5914F223F37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB081E61-BCAB-40B8-9358-A5914F223F37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB081E61-BCAB-40B8-9358-A5914F223F37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{626C7F5F-15EA-42AA-B4F8-5BD2A86B8FE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{626C7F5F-15EA-42AA-B4F8-5BD2A86B8FE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{626C7F5F-15EA-42AA-B4F8-5BD2A86B8FE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{626C7F5F-15EA-42AA-B4F8-5BD2A86B8FE6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A2C9D4D-2E3C-4726-ABC9-C77B41AE1DA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A2C9D4D-2E3C-4726-ABC9-C77B41AE1DA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A2C9D4D-2E3C-4726-ABC9-C77B41AE1DA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A2C9D4D-2E3C-4726-ABC9-C77B41AE1DA9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74F59396-7A67-474A-A404-97B038C237F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74F59396-7A67-474A-A404-97B038C237F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74F59396-7A67-474A-A404-97B038C237F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74F59396-7A67-474A-A404-97B038C237F3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1A2C9D4D-2E3C-4726-ABC9-C77B41AE1DA9} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{74F59396-7A67-474A-A404-97B038C237F3} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}
+	EndGlobalSection
+EndGlobal

--- a/projects/CompliantCSharp/CompliantCSharp.csproj
+++ b/projects/CompliantCSharp/CompliantCSharp.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/projects/CompliantCSharp/CompliantCSharp.csproj
+++ b/projects/CompliantCSharp/CompliantCSharp.csproj
@@ -1,7 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <AdditionalFiles Include="*.??proj" Visible="false" />
+  </ItemGroup>
 
 </Project>

--- a/projects/CompliantCSharp/Placeholder.cs
+++ b/projects/CompliantCSharp/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace ComplaintCSharp;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/projects/CompliantVB/CompliantVB.vbproj
+++ b/projects/CompliantVB/CompliantVB.vbproj
@@ -3,6 +3,11 @@
   <PropertyGroup>
     <RootNamespace>CompliantVB</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <OptionStrict>On</OptionStrict>
   </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="*.??proj" Visible="false" />
+  </ItemGroup>
 
 </Project>

--- a/projects/CompliantVB/CompliantVB.vbproj
+++ b/projects/CompliantVB/CompliantVB.vbproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>CompliantVB</RootNamespace>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/projects/CompliantVB/Placeholder.vb
+++ b/projects/CompliantVB/Placeholder.vb
@@ -1,0 +1,3 @@
+<Serializable>
+Public NotInheritable Class Placeholder
+End Class

--- a/projects/NoAdditionalFiles/NoAdditionalFiles.csproj
+++ b/projects/NoAdditionalFiles/NoAdditionalFiles.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/projects/NoAdditionalFiles/Placeholder.cs
+++ b/projects/NoAdditionalFiles/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace NoAdditionalFiles;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/rules/Proj0001.md
+++ b/rules/Proj0001.md
@@ -1,0 +1,7 @@
+# Proj0001: .NET project file could not be located
+Roslyn officially does not support the analysis on .NET project files. Therefor
+all rules in this package try to resolve the project file on disk based on
+(naming and location) conventions.
+
+This rule reports when the project file could not be located, due to whatever
+reason.

--- a/rules/Proj0001.md
+++ b/rules/Proj0001.md
@@ -1,6 +1,6 @@
 # Proj0001: .NET project file could not be located
-Roslyn officially does not support the analysis on .NET project files. Therefor
-all rules in this package try to resolve the project file on disk based on
+Roslyn officially does not support the analysis on .NET project files.
+Therefore all rules in this package try to resolve the project file based on
 (naming and location) conventions.
 
 This rule reports when the project file could not be located, due to whatever

--- a/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+using System.Reflection;
+
+namespace Design_specs;
+
+public class Rules
+{
+    [TestCaseSource(nameof(Types))]
+    public void in_DotNetProjectFile_Analyzers_namespace(Type type)
+        => type.Namespace.Should().Be("DotNetProjectFile.Analyzers");
+
+    [TestCaseSource(nameof(Types))]
+    public void Has_supported_diagnostics(Type type)
+        => ((DiagnosticAnalyzer)Activator.CreateInstance(type)!).SupportedDiagnostics.Should().NotBeEmpty();
+
+    [TestCaseSource(nameof(Types))]
+    public void for_CSharp_and_VB(Type type)
+        => type.GetCustomAttribute<DiagnosticAnalyzerAttribute>()!
+        .Languages.Should().BeEquivalentTo("C#", "Visual Basic");
+
+    private static IEnumerable<Type> Types
+        => typeof(DotNetProjectFile.ProjectFileAnalyzer).Assembly
+        .GetTypes()
+        .Where(t => !t.IsAbstract && t.IsAssignableTo(typeof(DiagnosticAnalyzer)));
+}
+

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Specs</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="TestTools">
+    <PackageReference Include="coverlet.collector" Version="*" />
+    <PackageReference Include="coverlet.msbuild" Version="*" />
+    <PackageReference Include="CodeAnalysis.TestTools" Version="1.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="NuGet.Common" Version="6.6.1" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.6.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.6.1" />
+    <PackageReference Include="NUnit" Version="3.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.*" />
+  </ItemGroup>
+
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="AsyncFixer" Version="*" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="*" />
+    <PackageReference Include="NUnit.Analyzers" Version="*" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotNetProjectFile.Analyzers\DotNetProjectFile.Analyzers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -16,7 +16,7 @@
   <ItemGroup Label="TestTools">
     <PackageReference Include="coverlet.collector" Version="*" />
     <PackageReference Include="coverlet.msbuild" Version="*" />
-    <PackageReference Include="CodeAnalysis.TestTools" Version="1.0.0" />
+    <PackageReference Include="CodeAnalysis.TestTools" Version="1.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="NuGet.Common" Version="6.6.1" />

--- a/specs/DotNetProjectFile.Analyzers.Specs/Extensions/Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Extensions/Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.cs
@@ -1,0 +1,26 @@
+﻿using CodeAnalysis.TestTools;
+using CodeAnalysis.TestTools.Contexts;
+
+namespace Microsoft.CodeAnalysis.Diagnostics;
+
+internal static class DiagnosticAnalyzerExtensions
+{
+    public static ProjectAnalyzerVerifyContext ForProject(this DiagnosticAnalyzer analyzer, string fileName)
+    {
+        var name = Path.GetFileNameWithoutExtension(fileName);
+        var file = new FileInfo($"../../../../../projects/{name}/{fileName}proj");
+        var context = analyzer.ForProject(file);
+
+        return context with
+        {
+            IgnoredDiagnostics = DiagnosticIds.Empty.AddRange(
+                "BC50001", // Unused import statement.
+
+                "CS8019", // Unnecessary using directive.
+                "CS8933", // The using directive appeared previously as global using
+                
+                "??????"
+            ),
+        };
+    }
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Extensions/System.Threading.Tasks.Run.Sync.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Extensions/System.Threading.Tasks.Run.Sync.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics.Contracts;
+
+namespace System.Threading.Tasks;
+
+/// <remarks>
+/// Microsoft built an AsyncHelper (internal) class to run Async as Sync.
+/// This implementation is equal to that one, besides some naming.
+/// </remarks>
+internal static class Run
+{
+    [Pure]
+    public static TResult Sync<TResult>(Func<Task<TResult>> task)
+        => Factory
+            .StartNew(task)
+            .Unwrap()
+            .GetAwaiter()
+            .GetResult();
+
+    public static void Sync(Func<Task> task)
+        => Factory
+            .StartNew(task)
+            .Unwrap()
+            .GetAwaiter()
+            .GetResult();
+
+    private static readonly TaskFactory Factory = new(
+       CancellationToken.None,
+       TaskCreationOptions.None,
+       TaskContinuationOptions.None,
+       TaskScheduler.Default);
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/FindsExtensions.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/FindsExtensions.cs
@@ -6,7 +6,7 @@ namespace FluentAssertions;
 internal static class FindsExtensions
 {
     public static void HasNoIssues(this ProjectAnalyzerVerifyContext context)
-        => context.HasIssues();
+        => context.HasIssues(Array.Empty<Issue>());
 
     public static void HasIssue(this ProjectAnalyzerVerifyContext context, Issue issue)
         => context.HasIssues(issue);

--- a/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/FindsExtensions.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/FindsExtensions.cs
@@ -1,0 +1,23 @@
+﻿using CodeAnalysis.TestTools.Contexts;
+using Microsoft.CodeAnalysis;
+
+namespace FluentAssertions;
+
+internal static class FindsExtensions
+{
+    public static void HasNoIssues(this ProjectAnalyzerVerifyContext context)
+        => context.HasIssues();
+
+    public static void HasIssue(this ProjectAnalyzerVerifyContext context, Issue issue)
+        => context.HasIssues(issue);
+    
+    public static void HasIssues(this ProjectAnalyzerVerifyContext context, params Issue[] issues)
+    {
+        var reported = Run.Sync(context.GetDiagnosticsAsync)
+            .Where(d => !context.IgnoredDiagnostics.Contains(d.Id))
+            .Select(Issue.FromDiagnostic)
+            .ToArray();
+
+        reported.Should().BeEquivalentTo(issues);
+    }
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/Issue.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/Issue.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace FluentAssertions;
+
+internal sealed record Issue(string Id, string Message, DiagnosticSeverity Severity = DiagnosticSeverity.Warning)
+{
+    public override string ToString() => Severity == DiagnosticSeverity.Warning
+        ? $"{Id} {Message}"
+        : $"{Id} {Message} ({Severity})";
+
+    public static Issue FromDiagnostic(Diagnostic diagnostic)
+        => new(diagnostic.Id, diagnostic.GetMessage(), diagnostic.Severity);
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Properties/GlobalUsings.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Properties/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using FluentAssertions;
+global using NUnit.Framework;

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Project_file_could_not_be_located.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Project_file_could_not_be_located.cs
@@ -1,0 +1,15 @@
+﻿using CodeAnalysis.TestTools;
+using DotNetProjectFile.Analyzers;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Rules.Project_file_could_not_be_located;
+
+public class Has_no_issues
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    public void For(string project)
+        => new ProjectFileCouldNotBeLocated()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Project_file_could_not_be_located.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Project_file_could_not_be_located.cs
@@ -8,6 +8,7 @@ public class Has_no_issues
 {
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantVB.vb")]
+    [TestCase("NoAdditionalFiles.cs")]
     public void For(string project)
         => new ProjectFileCouldNotBeLocated()
         .ForProject(project)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/ProjectFileCouldNotBeLocated.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/ProjectFileCouldNotBeLocated.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace DotNetProjectFile.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class ProjectFileCouldNotBeLocated : ProjectFileAnalyzer
+{
+    public ProjectFileCouldNotBeLocated() : base(Rule.ProjectFileCouldNotBeLocated) { }
+
+    protected override void Register(AnalysisContext context)
+        => context.RegisterCompilationAction(Locate);
+
+    private void Locate(CompilationAnalysisContext context)
+    {
+        if (Xml.Project.Create(context.Compilation) is null)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.None, context.Compilation.SourceModule.ContainingAssembly.Name));
+        }
+    }
+
+    [ExcludeFromCodeCoverage/* Justification = "Analyzer ensure that this is called for other analyzers." */]
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        // Empty.
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/ProjectFileCouldNotBeLocated.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/ProjectFileCouldNotBeLocated.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
+﻿using DotNetProjectFile.IO;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace DotNetProjectFile.Analyzers;
 
@@ -12,7 +13,7 @@ public sealed class ProjectFileCouldNotBeLocated : ProjectFileAnalyzer
 
     private void Locate(CompilationAnalysisContext context)
     {
-        if (Xml.Project.Create(context.Compilation) is null)
+        if (ProjectFileResolver.Resolve(context) is null)
         {
             context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.None, context.Compilation.SourceModule.ContainingAssembly.Name));
         }

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/Category.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/Category.cs
@@ -2,7 +2,7 @@
 
 public enum Category
 {
-    Clairity,
+    Clarity,
     Configuration,
     Reliability,
 }

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/Category.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/Category.cs
@@ -1,0 +1,8 @@
+﻿namespace DotNetProjectFile.Diagnostics;
+
+public enum Category
+{
+    Clairity,
+    Configuration,
+    Reliability,
+}

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/CollectionDebugView.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/CollectionDebugView.cs
@@ -1,0 +1,23 @@
+﻿namespace DotNetProjectFile.Diagnostics;
+
+/// <summary>Allows the debugger to display collections.</summary>
+[ExcludeFromCodeCoverage]
+internal sealed class CollectionDebugView
+{
+    /// <summary>Initializes a new instance of the <see cref="CollectionDebugView"/> class.</summary>
+    /// <param name="enumeration">
+    /// The collection to show the elements of.
+    /// </param>
+    public CollectionDebugView(IEnumerable enumeration) => this.enumeration = enumeration;
+
+    /// <summary>The array that is shown by the debugger.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+#pragma warning disable S2365 // Properties should not make collection or array copies
+    // Every time the enumeration is shown in the debugger, a new array is created.
+    // By doing this, it is always in sync with the current state of the enumeration.
+    public object[] Items => enumeration.Cast<object>().ToArray();
+#pragma warning restore S2365 // Properties should not make collection or array copies
+
+    /// <summary>A reference to the enumeration to display.</summary>
+    private readonly IEnumerable enumeration;
+}

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -32,5 +32,5 @@ public readonly struct ProjectFileAnalysisContext
 
     /// <summary>Reports a diagnostic about the project file.</summary>
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, params object[] messageArgs)
-       => Report(Diagnostic.Create(descriptor, Location.None, messageArgs));
+        => Report(Diagnostic.Create(descriptor, Location.None, messageArgs));
 }

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace DotNetProjectFile.Diagnostics;
+
+/// <summary>The context required to analyze a .NET project file.</summary>
+public readonly struct ProjectFileAnalysisContext
+{
+    /// <summary>Gets the project file.</summary>
+    public readonly Xml.Project Project;
+
+    /// <summary>Gets the compilation.</summary>
+    public readonly Compilation Compilation;
+
+    /// <summary>Gets the analyzer options.</summary>
+    public readonly AnalyzerOptions Options;
+
+    /// <summary>Gets the cancellation token.</summary>
+    public readonly CancellationToken CancellationToken;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly Action<Diagnostic> Report;
+
+    /// <summary>Initializes a new instance of the <see cref="ProjectFileAnalysisContext"/> struct.</summary>
+    public ProjectFileAnalysisContext(Xml.Project project, Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken, Action<Diagnostic> report)
+    {
+        Project = project;
+        Compilation = compilation;
+        Options = options;
+        CancellationToken = cancellationToken;
+        Report = report;
+    }
+
+    /// <summary>Reports a diagnostic about the project file.</summary>
+    public void ReportDiagnostic(DiagnosticDescriptor descriptor, params object[] messageArgs)
+       => Report(Diagnostic.Create(descriptor, Location.None, messageArgs));
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -17,7 +17,7 @@
     <Version>1.0.0</Version>
     <PackageReleaseNotes>
 v1.0.0
-- Proj0001: .NET project file could not be located
+- Proj0001: .NET project file could not be located.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -11,8 +11,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
-    <PackageProjectUrl>http://www.github.com/Corniel/dotnet-project-analyzers</PackageProjectUrl>
-    <RepositoryUrl>http://www.github.com/Corniel/dotnet-project-analyzers</RepositoryUrl>
+    <PackageProjectUrl>http://www.github.com/Corniel/dotnet-project-files-analyzers</PackageProjectUrl>
+    <RepositoryUrl>http://www.github.com/Corniel/dotnet-project-files-analyzers</RepositoryUrl>
     <PackageTags>Code Analysis;Project files;csproj;vbproj</PackageTags>
     <Version>1.0.0</Version>
     <PackageReleaseNotes>

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -1,0 +1,42 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
+    <RootNamespace>DotNetProjectFile</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Package settings">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>http://www.github.com/Corniel/dotnet-project-analyzers</PackageProjectUrl>
+    <RepositoryUrl>http://www.github.com/Corniel/dotnet-project-analyzers</RepositoryUrl>
+    <PackageTags>Code Analysis;Project files;csproj;vbproj</PackageTags>
+    <Version>1.0.0</Version>
+    <PackageReleaseNotes>
+v1.0.0
+- Proj0001: .NET project file could not be located
+    </PackageReleaseNotes>
+  </PropertyGroup>
+
+  <ItemGroup Label="Package files">
+    <None Update="tools\*.ps1" Pack="true" PackagePath="\" />
+    <None Include="$(OutputPath)\DotNetProjectFile.Analyzers.dll" Pack="true" PackagePath="analyzers" Visible="false" />
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.*" />
+  </ItemGroup>
+
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="AsyncFixer" Version="*-*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="Qowaiv.Analyzers.CSharp" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="StyleCop.Analyzers" Version="*-*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+  </ItemGroup>
+  
+</Project>

--- a/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
@@ -1,0 +1,15 @@
+﻿namespace Microsoft.CodeAnalysis.Diagnostics;
+
+/// <summary>Extensions on <see cref="AnalysisContext"/>.</summary>
+internal static class AnalysisContextExtensions
+{
+    /// <summary>Registers an action on <see cref="ProjectFileAnalysisContext"/>.</summary>
+    public static void RegisterProjectFileAction(this AnalysisContext context, Action<ProjectFileAnalysisContext> action)
+        => context.RegisterCompilationAction(c =>
+        {
+            if (DotNetProjectFile.Xml.Project.Create(c.Compilation) is { } project)
+            {
+                action.Invoke(new(project, c.Compilation, c.Options, c.CancellationToken, c.ReportDiagnostic));
+            }
+        });
+}

--- a/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.CodeAnalysis.Diagnostics;
+﻿using DotNetProjectFile.IO;
+
+namespace Microsoft.CodeAnalysis.Diagnostics;
 
 /// <summary>Extensions on <see cref="AnalysisContext"/>.</summary>
 internal static class AnalysisContextExtensions
@@ -7,7 +9,7 @@ internal static class AnalysisContextExtensions
     public static void RegisterProjectFileAction(this AnalysisContext context, Action<ProjectFileAnalysisContext> action)
         => context.RegisterCompilationAction(c =>
         {
-            if (DotNetProjectFile.Xml.Project.Create(c.Compilation) is { } project)
+            if (ProjectFileResolver.Resolve(c) is { } project)
             {
                 action.Invoke(new(project, c.Compilation, c.Options, c.CancellationToken, c.ReportDiagnostic));
             }

--- a/src/DotNetProjectFile.Analyzers/IO/DirectoryEqualityComparer.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/DirectoryEqualityComparer.cs
@@ -1,0 +1,12 @@
+﻿using System.IO;
+
+namespace DotNetProjectFile.IO;
+
+internal sealed class DirectoryEqualityComparer : IEqualityComparer<DirectoryInfo>
+{
+    public static readonly DirectoryEqualityComparer Instance = new();
+
+    public bool Equals(DirectoryInfo x, DirectoryInfo y) => x.FullName == y.FullName;
+
+    public int GetHashCode(DirectoryInfo obj) => obj.FullName.GetHashCode();
+}

--- a/src/DotNetProjectFile.Analyzers/IO/ProjectFileResolver.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/ProjectFileResolver.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+using System.IO;
+
+namespace DotNetProjectFile.IO;
+
+public static class ProjectFileResolver
+{
+    public static Xml.Project? Resolve(CompilationAnalysisContext context)
+    {
+        if (context.Compilation.SourceModule.ContainingAssembly is { } assembly)
+        {
+            var isProject = IsProject(context.Compilation.Options.Language);
+
+            return Resolve(context.Options.AdditionalFiles, assembly.Name, isProject)
+                ?? Resolve(assembly.Locations, assembly.Name, isProject);
+        }
+        return null;
+    }
+
+    private static Xml.Project? Resolve(IEnumerable<AdditionalText> texts, string assemblyName, Func<FileInfo, string, bool> isProject)
+    {
+        var additionals = texts
+               .Where(f => isProject(new(f.Path), assemblyName))
+               .ToArray();
+
+        return additionals.Length == 1
+            ? Xml.Project.Load(additionals[0])
+            : null;
+    }
+
+    private static Xml.Project? Resolve(IEnumerable<Location> locations, string assemblyName, Func<FileInfo, string, bool> isProject)
+    {
+        var directories = locations.Select(l => l.SourceTree?.FilePath)
+               .Where(path => path is { })
+               .Select(path => new FileInfo(path))
+               .SelectMany(Ancestors)
+               .Distinct(DirectoryEqualityComparer.Instance)
+               .Where(f => f.Exists);
+
+        var files = directories.SelectMany(d => d.EnumerateFiles())
+            .Where(f => isProject(f, assemblyName))
+            .ToArray();
+
+        return files.Length == 1
+           ? Xml.Project.Load(files[0])
+           : null;
+    }
+
+    private static IEnumerable<DirectoryInfo> Ancestors(FileInfo file)
+    {
+        var current = file.Directory;
+        while (current is { })
+        {
+            yield return current;
+            current = current.Parent;
+        }
+    }
+
+    private static Func<FileInfo, string, bool> IsProject(string language)
+        => language switch
+        {
+            LanguageNames.CSharp => (f, n) => IsProject(f, ".csproj", n),
+            LanguageNames.VisualBasic => (f, n) => IsProject(f, ".vbproj", n),
+            _ => (_, _) => false,
+        };
+
+    private static bool IsProject(FileInfo file, string extension, string assemblyName)
+        => file.Exists
+        && string.Equals(file.Extension, extension, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(Path.GetFileNameWithoutExtension(file.Name), assemblyName, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/DotNetProjectFile.Analyzers/IO/ProjectFileResolver.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/ProjectFileResolver.cs
@@ -59,13 +59,19 @@ public static class ProjectFileResolver
     private static Func<FileInfo, string, bool> IsProject(string language)
         => language switch
         {
-            LanguageNames.CSharp => (f, n) => IsProject(f, ".csproj", n),
-            LanguageNames.VisualBasic => (f, n) => IsProject(f, ".vbproj", n),
-            _ => (_, _) => false,
+            LanguageNames.CSharp => IsCSharpProject,
+            LanguageNames.VisualBasic => IsVBProject,
+            _ => NoMatch,
         };
 
-    private static bool IsProject(FileInfo file, string extension, string assemblyName)
+    private static bool IsCSharpProject(FileInfo file, string name) => IsProject(file, name, ".csproj");
+
+    private static bool IsVBProject(FileInfo file, string name) => IsProject(file, name, ".vbproj");
+
+    private static bool NoMatch(FileInfo _, string __) => false;
+
+    private static bool IsProject(FileInfo file, string name, string extension)
         => file.Exists
         && string.Equals(file.Extension, extension, StringComparison.OrdinalIgnoreCase)
-        && string.Equals(Path.GetFileNameWithoutExtension(file.Name), assemblyName, StringComparison.OrdinalIgnoreCase);
+        && string.Equals(Path.GetFileNameWithoutExtension(file.Name), name, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/DotNetProjectFile.Analyzers/ProjectFileAnalyzer.cs
+++ b/src/DotNetProjectFile.Analyzers/ProjectFileAnalyzer.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace DotNetProjectFile;
+
+public abstract class ProjectFileAnalyzer : DiagnosticAnalyzer
+{
+    protected ProjectFileAnalyzer(DiagnosticDescriptor primaryDiagnostic, params DiagnosticDescriptor[] supportedDiagnostics)
+        => SupportedDiagnostics = new[] { primaryDiagnostic }.Concat(supportedDiagnostics).ToImmutableArray();
+
+    public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+
+    public DiagnosticDescriptor Descriptor => SupportedDiagnostics[0];
+
+    public sealed override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        Register(context);
+    }
+
+    protected virtual void Register(AnalysisContext context)
+        => context.RegisterProjectFileAction(Register);
+
+    protected abstract void Register(ProjectFileAnalysisContext context);
+}

--- a/src/DotNetProjectFile.Analyzers/Properties/GlobalUsings.cs
+++ b/src/DotNetProjectFile.Analyzers/Properties/GlobalUsings.cs
@@ -1,0 +1,9 @@
+﻿global using DotNetProjectFile.Diagnostics;
+global using Microsoft.CodeAnalysis;
+global using System;
+global using System.Collections;
+global using System.Collections.Generic;
+global using System.Diagnostics;
+global using System.Diagnostics.CodeAnalysis;
+global using System.Linq;
+global using System.Threading;

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -1,0 +1,5 @@
+# .NET project file analyzers
+The package contains analyzers that analyze .NET project files.
+
+## Rules
+* [**Proj0001** .NET project file could not be located](https://github.com/Corniel/dotnet-project-analyzers/blob/main/rules/Proj0001.md)

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -2,4 +2,4 @@
 The package contains analyzers that analyze .NET project files.
 
 ## Rules
-* [**Proj0001** .NET project file could not be located](https://github.com/Corniel/dotnet-project-analyzers/blob/main/rules/Proj0001.md)
+* [**Proj0001** .NET project file could not be located](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0001.md)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -33,5 +33,5 @@ public static class Rule
             defaultSeverity: severity,
             isEnabledByDefault: isEnabled,
             description: description,
-            helpLinkUri: $"https://github.com/Corniel/dotnet-project-analyzers/blob/main/rules/Proj{id:0000}.md");
+            helpLinkUri: $"https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj{id:0000}.md");
 }

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -6,7 +6,7 @@ public static class Rule
         id: 0001,
         title: ".NET project file could not be located",
         message: "The project file '{0}' could not be located.",
-        description: "In order to make this rules work, the project file should be located.",
+        description: "In order to make these rules work, the project file should be located.",
         tags: new[] { "Configuration" },
         category: Category.Configuration,
         severity: DiagnosticSeverity.Warning,

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -1,0 +1,37 @@
+﻿namespace DotNetProjectFile;
+
+public static class Rule
+{
+    public static DiagnosticDescriptor ProjectFileCouldNotBeLocated => New(
+        id: 0001,
+        title: ".NET project file could not be located",
+        message: "The project file '{0}' could not be located.",
+        description: "In order to make this rules work, the project file should be located.",
+        tags: new[] { "Configuration" },
+        category: Category.Configuration,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
+#pragma warning disable S107 // Methods should not have too many parameters
+    // it calls a ctor with even more arguments.
+    private static DiagnosticDescriptor New(
+        int id,
+        string title,
+        string message,
+        string description,
+        string[] tags,
+        Category category,
+        DiagnosticSeverity severity = DiagnosticSeverity.Warning,
+        bool isEnabled = true)
+#pragma warning restore S107 // Methods should not have too many parameters
+        => new(
+            id: $"Proj{id:0000}",
+            title: title,
+            messageFormat: message,
+            customTags: tags,
+            category: category.ToString(),
+            defaultSeverity: severity,
+            isEnabledByDefault: isEnabled,
+            description: description,
+            helpLinkUri: $"https://github.com/Corniel/dotnet-project-analyzers/blob/main/rules/Proj{id:0000}.md");
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/Conversion/StringConverter.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Conversion/StringConverter.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel;
+using System.Globalization;
+
+namespace DotNetProjectFile.Xml.Conversion;
+
+internal sealed class StringConverter : TypeConverter
+{
+    public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        => sourceType == typeof(string)
+        || base.CanConvertFrom(context, sourceType);
+
+    public override object? ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        => value is null || value is string
+        ? value as string
+        : base.ConvertFrom(context, culture, value);
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/Conversion/TypeConverters.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Conversion/TypeConverters.cs
@@ -1,0 +1,62 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+
+namespace DotNetProjectFile.Xml.Conversion;
+
+internal sealed class TypeConverters
+{
+    public T? TryConvert<T>(string? value, Type classType, string propertyName)
+    {
+        try
+        {
+            if (value is { })
+            {
+                return (T?)Get(classType, propertyName!).ConvertFromString(value);
+            }
+        }
+        catch
+        {
+            // Conversion failed.
+        }
+        return default;
+    }
+
+    public TypeConverter Get(Type classType, string propertyName)
+    {
+        var property = classType.GetProperty(propertyName);
+
+        if (PropertyStore.TryGetValue(property, out TypeConverter converter))
+        {
+            return converter;
+        }
+
+        lock (locker)
+        {
+            if (!PropertyStore.TryGetValue(property, out converter))
+            {
+                if (property.GetCustomAttribute<TypeConverterAttribute>(true) is { } attr)
+                {
+                    converter = (TypeConverter)Activator.CreateInstance(Type.GetType(attr.ConverterTypeName));
+                }
+                else if (!TypeStore.TryGetValue(property.PropertyType, out converter))
+                {
+                    var type = Nullable.GetUnderlyingType(property.PropertyType)
+                        ?? property.PropertyType;
+
+                    converter = TypeDescriptor.GetConverter(type);
+                    TypeStore[property.PropertyType] = converter;
+                }
+                PropertyStore[property] = converter;
+            }
+        }
+        return converter;
+    }
+
+    private readonly Dictionary<PropertyInfo, TypeConverter> PropertyStore = new();
+    private readonly Dictionary<Type, TypeConverter> TypeStore = new()
+    {
+        [typeof(string)] = new StringConverter(),
+    };
+
+    private readonly object locker = new();
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/ItemGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/ItemGroup.cs
@@ -1,0 +1,27 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Xml;
+
+/// <summary>Represents an item group in a Visual Studio project file.</summary>
+/// <remarks>
+/// Often, an item group only contains one type of children:
+/// - Compile
+/// - Content
+/// - EmbeddedResource
+/// - Import
+/// - None
+/// - PackageReference
+/// - ProjectReference
+/// - Reference.
+/// </remarks>
+public sealed class ItemGroup : Node
+{
+    /// <summary>Initializes a new instance of the <see cref="ItemGroup"/> class.</summary>
+    /// <param name="element">
+    /// The corresponding <see cref="XElement"/>.
+    /// </param>
+    public ItemGroup(XElement element) : base(element) { }
+
+    /// <summary>Gets the child package references.</summary>
+    public Nodes<PackageReference> PackageReferences => GetChildren<PackageReference>();
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Node.cs
@@ -1,0 +1,71 @@
+﻿using System.Runtime.CompilerServices;
+using System.Xml;
+using System.Xml.Linq;
+using DotNetProjectFile.Xml.Conversion;
+
+namespace DotNetProjectFile.Xml;
+
+/// <summary>Represents node in a .NET project file.</summary>
+public class Node
+{
+    /// <summary>Initializes a new instance of the <see cref="Node"/> class.</summary>
+    protected Node(XElement element)
+    {
+        Element = element;
+    }
+
+    internal XElement Element { get; }
+
+    /// <summary>Gets the local name of the <see cref="Node"/>.</summary>
+    public virtual string LocalName => GetType().Name;
+
+    /// <summary>Gets the label of the node.</summary>
+    public string? Label => GetAttribute();
+
+    /// <summary>Get the line info.</summary>
+    public IXmlLineInfo LineInfo => Element;
+
+    /// <summary>Represents the node as an <see cref="string"/>.</summary>
+    /// <remarks>
+    /// The <see cref="XNode.ToString()"/> of the underlying <see cref="XElement"/> is called.
+    /// </remarks>
+    public override string ToString() => Element.ToString();
+
+    /// <summary>Gets the a <see cref="Nodes{T}"/> of children.</summary>
+    public Nodes<T> GetChildren<T>() where T : Node => new(this);
+
+    /// <summary>Gets the <see cref="string"/> value of a child element.</summary>
+    public string? GetAttribute([CallerMemberName] string? propertyName = null)
+        => Element.Attribute(propertyName)?.Value;
+
+    /// <summary>Gets the <see cref="string"/> value of a child element.</summary>
+    public string? GetNode([CallerMemberName] string? propertyName = null)
+        => Element.Element(propertyName)?.Value;
+
+    /// <summary>Gets the value of a child element.</summary>
+    public T? GetNode<T>([CallerMemberName] string? propertyName = null)
+        => Convert<T>(GetNode(propertyName), propertyName);
+
+    /// <summary>Get all children.</summary>
+    /// <remarks>
+    /// This function exists as source for the <see cref="Nodes{T}"/>.
+    /// With this construction, we can expose all children as collection.
+    /// </remarks>
+    internal IEnumerable<Node> GetAllChildren()
+        => Element.Elements().Select(Create).OfType<Node>();
+
+    internal static Node? Create(XElement element)
+    => element.Name.LocalName switch
+    {
+        null => null,
+        nameof(ItemGroup) /*..............*/ => new ItemGroup(element),
+        nameof(PackageReference) /*.......*/ => new PackageReference(element),
+        nameof(PropertyGroup) /*..........*/ => new PropertyGroup(element),
+        _ => new Unknown(element),
+    };
+
+    private T? Convert<T>(string? value, string? propertyName)
+        => Converters.TryConvert<T>(value, GetType(), propertyName!);
+
+    private static readonly TypeConverters Converters = new();
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/Nodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Nodes.cs
@@ -1,0 +1,47 @@
+﻿using System.Globalization;
+
+namespace DotNetProjectFile.Xml;
+
+/// <summary>Represents a collection of <see cref="Node"/>s.</summary>
+[DebuggerTypeProxy(typeof(Diagnostics.CollectionDebugView))]
+[DebuggerDisplay("{DebuggerDisplay}")]
+public sealed class Nodes<T> : IEnumerable<T> where T : Node
+{
+    /// <summary>Initializes a new instance of the <see cref="Nodes{T}"/> class.</summary>
+    /// <param name="parent">
+    /// The parent <see cref="Node"/>.
+    /// </param>
+    public Nodes(Node parent)
+    {
+        Parent = parent;
+    }
+
+    /// <summary>Gets the number of items.</summary>
+    public int Count => Items.Count();
+
+    /// <summary>Gets the specified item.</summary>
+    /// <param name="index">
+    /// The index of the item.
+    /// </param>
+    public T this[int index] => Items.Skip(index).FirstOrDefault();
+
+    /// <summary>The parent 
+    /// 
+    /// </summary>
+    private Node Parent { get; set; }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never), ExcludeFromCodeCoverage]
+    private string DebuggerDisplay
+        => string.Format(CultureInfo.InvariantCulture, "{0} Count = {1}", typeof(T).Name, Count);
+
+    /// <inheritdoc />
+    public IEnumerator<T> GetEnumerator() => Items.GetEnumerator();
+
+    /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
+    IEnumerator IEnumerable.GetEnumerator() =>GetEnumerator();
+
+    /// <summary>Helper property to select the needed children.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private IEnumerable<T> Items=> Parent.GetAllChildren().Where(child => child is T).Cast<T>();
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/Nodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Nodes.cs
@@ -25,12 +25,11 @@ public sealed class Nodes<T> : IEnumerable<T> where T : Node
     /// </param>
     public T this[int index] => Items.Skip(index).FirstOrDefault();
 
-    /// <summary>The parent 
-    /// 
-    /// </summary>
+    /// <summary>The parent node.</summary>
     private Node Parent { get; set; }
 
-    [DebuggerBrowsable(DebuggerBrowsableState.Never), ExcludeFromCodeCoverage]
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    [ExcludeFromCodeCoverage/* Justification = "Debug experience only." */]
     private string DebuggerDisplay
         => string.Format(CultureInfo.InvariantCulture, "{0} Count = {1}", typeof(T).Name, Count);
 
@@ -39,9 +38,9 @@ public sealed class Nodes<T> : IEnumerable<T> where T : Node
 
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
-    IEnumerator IEnumerable.GetEnumerator() =>GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <summary>Helper property to select the needed children.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private IEnumerable<T> Items=> Parent.GetAllChildren().Where(child => child is T).Cast<T>();
+    private IEnumerable<T> Items => Parent.GetAllChildren().Where(child => child is T).Cast<T>();
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/PackageReference.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/PackageReference.cs
@@ -1,0 +1,14 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Xml;
+
+public sealed class PackageReference : Node
+{
+    public PackageReference(XElement element) : base(element)
+    {
+    }
+
+    public string? Include => GetAttribute();
+
+    public string? Version => GetAttribute();
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Project.cs
@@ -1,0 +1,54 @@
+﻿using DotNetProjectFile.IO;
+using System.IO;
+using System.Xml.Linq;
+
+namespace DotNetProjectFile.Xml;
+
+public sealed class Project : Node
+{
+    public Project(XElement element) : base(element) { }
+
+    public Nodes<PropertyGroup> PropertyGroups => GetChildren<PropertyGroup>();
+
+    public Nodes<ItemGroup> ItemGroups => GetChildren<ItemGroup>();
+
+    public static Project Load(FileInfo file)
+        => new (XElement.Load(file.OpenRead(), LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo));
+    
+    public static Project? Create(Compilation compilation)
+    {
+        if (compilation.SourceModule.ContainingAssembly is { } assembly)
+        {
+            var directories = assembly.Locations.Select(l => l.SourceTree?.FilePath)
+                .Where(p => p is { })
+                .Select(p => new FileInfo(p).Directory)
+                .Distinct(DirectoryEqualityComparer.Instance)
+                .Where(f => f.Exists)
+                .ToArray();
+
+            var project = directories.Select(d => GetFile(d, $"{assembly.Name}.??proj"))
+                .FirstOrDefault(f => f is { });
+
+            if (project is { })
+            {
+                return Load(project);
+            }
+        }
+        return null;
+    }
+    private static FileInfo? GetFile(DirectoryInfo dir, string fileName)
+    {
+        FileInfo? file;
+        try
+        {
+            file = dir.GetFiles(fileName).FirstOrDefault();
+        }
+        catch
+        {
+            return null;
+        }
+        return file is null && dir.Parent is { }
+            ? GetFile(dir.Parent, fileName)
+            : file;
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Project.cs
@@ -13,8 +13,8 @@ public sealed class Project : Node
     public Nodes<ItemGroup> ItemGroups => GetChildren<ItemGroup>();
 
     public static Project Load(FileInfo file)
-        => new (XElement.Load(file.OpenRead(), LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo));
-    
+        => new(XElement.Load(file.OpenRead(), LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo));
+
     public static Project? Create(Compilation compilation)
     {
         if (compilation.SourceModule.ContainingAssembly is { } assembly)
@@ -36,6 +36,7 @@ public sealed class Project : Node
         }
         return null;
     }
+
     private static FileInfo? GetFile(DirectoryInfo dir, string fileName)
     {
         FileInfo? file;

--- a/src/DotNetProjectFile.Analyzers/Xml/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Project.cs
@@ -1,5 +1,4 @@
-﻿using DotNetProjectFile.IO;
-using System.IO;
+﻿using System.IO;
 using System.Xml.Linq;
 
 namespace DotNetProjectFile.Xml;
@@ -15,41 +14,6 @@ public sealed class Project : Node
     public static Project Load(FileInfo file)
         => new(XElement.Load(file.OpenRead(), LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo));
 
-    public static Project? Create(Compilation compilation)
-    {
-        if (compilation.SourceModule.ContainingAssembly is { } assembly)
-        {
-            var directories = assembly.Locations.Select(l => l.SourceTree?.FilePath)
-                .Where(p => p is { })
-                .Select(p => new FileInfo(p).Directory)
-                .Distinct(DirectoryEqualityComparer.Instance)
-                .Where(f => f.Exists)
-                .ToArray();
-
-            var project = directories.Select(d => GetFile(d, $"{assembly.Name}.??proj"))
-                .FirstOrDefault(f => f is { });
-
-            if (project is { })
-            {
-                return Load(project);
-            }
-        }
-        return null;
-    }
-
-    private static FileInfo? GetFile(DirectoryInfo dir, string fileName)
-    {
-        FileInfo? file;
-        try
-        {
-            file = dir.GetFiles(fileName).FirstOrDefault();
-        }
-        catch
-        {
-            return null;
-        }
-        return file is null && dir.Parent is { }
-            ? GetFile(dir.Parent, fileName)
-            : file;
-    }
+    internal static Project Load(AdditionalText text)
+        => new(XElement.Parse(text.GetText()?.ToString()));
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/PropertyGroup.cs
@@ -1,0 +1,22 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Xml;
+
+public sealed class PropertyGroup : Node
+{
+    public enum ImplicitUsingKind
+    {
+        disable,
+        enable,
+        @true,
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="PropertyGroup"/> class.</summary>
+    public PropertyGroup(XElement element) : base(element) { }
+
+    public ImplicitUsingKind? ImplicitUsings => GetNode<ImplicitUsingKind?>();
+
+    public NullableContextOptions? Nullable => GetNode<NullableContextOptions?>();
+
+    public string? RootNamespace => GetNode();
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/Unknown.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Unknown.cs
@@ -1,0 +1,16 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Xml;
+
+/// <summary>Represents an unknown node. So, a node that is not specified by VSDom.Projects.</summary>
+public sealed class Unknown : Node
+{
+    /// <summary>Initializes a new instance of a <see cref="Unknown"/>.</summary>
+    /// <param name="element">
+    /// The corresponding <see cref="XElement"/>.
+    /// </param>
+    public Unknown(XElement element) : base(element) { }
+
+    /// <summary>Gets the local name of the <see cref="Unknown"/>.</summary>
+    public override string LocalName => Element.Name.LocalName;
+}

--- a/src/DotNetProjectFile.Analyzers/tools/install.ps1
+++ b/src/DotNetProjectFile.Analyzers/tools/install.ps1
@@ -1,0 +1,10 @@
+param($installPath, $toolsPath, $package, $project)
+
+if ($project.Object.AnalyzerReferences -eq $null) {
+    throw 'This package cannot be installed without an analyzer reference.'
+}
+
+$analyzersPath = Split-Path -Path $toolsPath -Parent
+$analyzersPath = Join-Path $toolsPath "analyzers"
+$analyzerFilePath = Join-Path $analyzersPath "DotNetProjectFile.Analyzers.dll"
+$project.Object.AnalyzerReferences.Add($analyzerFilePath)

--- a/src/DotNetProjectFile.Analyzers/tools/uninstall.ps1
+++ b/src/DotNetProjectFile.Analyzers/tools/uninstall.ps1
@@ -1,0 +1,10 @@
+param($installPath, $toolsPath, $package, $project)
+
+$analyzersPath = Split-Path -Path $toolsPath -Parent
+$analyzersPath = Join-Path $toolsPath "analyzers"
+$analyzerFilePath = Join-Path $analyzersPath "DotNetProjectFile.Analyzers.dll"
+try {
+    $project.Object.AnalyzerReferences.Remove($analyzerFilePath)
+}
+catch {
+}


### PR DESCRIPTION
So that other rules don't have to crash (or all report) that the .NET project file could not be resolved, this rule handles that scenario for them.