### PR TITLE
New Rule Proj0003: Define usings explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,23 @@ In a props file:
 * [**Proj0001** .NET project file could not be located](rules/Proj0001.md)
 * [**Proj0003** Define usings explicit](rules/Proj0003.md)
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
+
+## Reference an analyzer from a project
+For debugging/development purposes, it can be useful reference the analyzer
+project directly. Within this solution, that could like:
+
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup Label="Analyzer">
+    <ProjectReference
+        Include="../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj"
+        PrivateAssets="all"
+        ReferenceOutputAssembly="false"
+        OutputItemType="Analyzer"
+        SetTargetFramework="TargetFramework=netstandard2.0" />
+  </ItemGroup>
+</Project>
+```
+
+More info can be found here: https://www.meziantou.net/referencing-an-analyzer-from-a-project.htm

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ project directly. Within this solution, that could like:
         OutputItemType="Analyzer"
         SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
+
 </Project>
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,4 +34,5 @@ In a props file:
 
 ## Rules
 * [**Proj0001** .NET project file could not be located](rules/Proj0001.md)
-* [**Proj1001** "Use analyzers for packages](rules/Proj1001.md)
+* [**Proj0003** Define usings explicit](rules/Proj0003.md)
+* [**Proj1001** Use analyzers for packages](rules/Proj1001.md)

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ In a props file:
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
 
 ## Reference an analyzer from a project
-For debugging/development purposes, it can be useful reference the analyzer
-project directly. Within this solution, that could like:
+For debugging/development purposes, it can be useful to reference the analyzer
+project directly. Within this solution, that would look like:
 
 ``` XML
 <Project Sdk="Microsoft.NET.Sdk">

--- a/build.sln
+++ b/build.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{00669DF6
 		projects\props\common.props = projects\props\common.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitUsings", "projects\ImplicitUsings\ImplicitUsings.csproj", "{D525C7B7-5B0B-489D-BC3E-968597F84A58}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +48,10 @@ Global
 		{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D525C7B7-5B0B-489D-BC3E-968597F84A58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D525C7B7-5B0B-489D-BC3E-968597F84A58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D525C7B7-5B0B-489D-BC3E-968597F84A58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D525C7B7-5B0B-489D-BC3E-968597F84A58}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -55,6 +61,7 @@ Global
 		{74F59396-7A67-474A-A404-97B038C237F3} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{00669DF6-1449-41AA-8AD3-FA84194CE5B4} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{D525C7B7-5B0B-489D-BC3E-968597F84A58} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -22,6 +22,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3-2049-4539-8A37-D370EE0F91F7}"
 	ProjectSection(SolutionItems) = preProject
 		rules\Proj0001.md = rules\Proj0001.md
+		rules\Proj0003.md = rules\Proj0003.md
 		rules\Proj1001.md = rules\Proj1001.md
 	EndProjectSection
 EndProject
@@ -46,6 +47,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{00669DF6
 	ProjectSection(SolutionItems) = preProject
 		projects\props\common.props = projects\props\common.props
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImplicitUsings", "projects\ImplicitUsings\ImplicitUsings.csproj", "{64D2404F-D04E-4926-8503-0D0C97C1EDBC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +84,10 @@ Global
 		{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64D2404F-D04E-4926-8503-0D0C97C1EDBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64D2404F-D04E-4926-8503-0D0C97C1EDBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64D2404F-D04E-4926-8503-0D0C97C1EDBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64D2404F-D04E-4926-8503-0D0C97C1EDBC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -94,6 +101,7 @@ Global
 		{5D9A3040-DBCD-4401-8B2F-369586DEF29F} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{00669DF6-1449-41AA-8AD3-FA84194CE5B4} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{64D2404F-D04E-4926-8503-0D0C97C1EDBC} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/ImplicitUsings/ImplicitUsings.csproj
+++ b/projects/ImplicitUsings/ImplicitUsings.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>

--- a/projects/ImplicitUsings/ImplicitUsings.csproj
+++ b/projects/ImplicitUsings/ImplicitUsings.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="*.??proj" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/projects/ImplicitUsings/Placeholder.cs
+++ b/projects/ImplicitUsings/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace ImplicitUsings;
+
+[Serializable]
+public sealed class Placeholder { }

--- a/rules/Proj0003.md
+++ b/rules/Proj0003.md
@@ -3,30 +3,31 @@
 Once enabled, depending on the type of project you have created you'll have the
 following global using statements added to your project implicitly.
 
-| SDK                      | Default namespaces                       |
-|--------------------------|------------------------------------------|
-| Microsoft.NET.Sdk        | System									  |
-|                          | System.Collections.Generic				  |
-|                          | System.IO								  |
-|                          | System.Linq							  |
-|                          | System.Net.Http						  |
-|                          | System.Threading						  |
-|                          | System.Threading.Tasks					  |
-|--------------------------|------------------------------------------|
-| Microsoft.NET.Sdk.Web    | System.Net.Http.Json					  |
-|                          | Microsoft.AspNetCore.Builder			  |
-|                          | Microsoft.AspNetCore.Hosting			  |
-|                          | Microsoft.AspNetCore.Http				  |
-|                          | Microsoft.AspNetCore.Routing			  |
-|                          | Microsoft.Extensions.Configuration		  |
-|                          | Microsoft.Extensions.DependencyInjection |
-|                          | Microsoft.Extensions.Hosting			  |
-|                          | Microsoft.Extensions.Logging			  |
-|--------------------------|------------------------------------------|
-| Microsoft.NET.Sdk.Worker | Microsoft.Extensions.Configuration		  |
-|                          | Microsoft.Extensions.DependencyInjection |
-|                          | Microsoft.Extensions.Hosting			  |
-|                          | Microsoft.Extensions.Logging			  |
+| SDK | Default namespaces                       |
+|-----|------------------------------------------|
+| **Microsoft.NET.Sdk**
+|     | System                                   |
+|     | System.Collections.Generic               |
+|     | System.IO                                |
+|     | System.Linq                              |
+|     | System.Net.Http                          |
+|     | System.Threading                         |
+|     | System.Threading.Tasks                   |
+| **Microsoft.NET.Sdk.Web**
+|     | System.Net.Http.Json                     |
+|     | Microsoft.AspNetCore.Builder             |
+|     | Microsoft.AspNetCore.Hosting             |
+|     | Microsoft.AspNetCore.Http                |
+|     | Microsoft.AspNetCore.Routing             |
+|     | Microsoft.Extensions.Configuration       |
+|     | Microsoft.Extensions.DependencyInjection |
+|     | Microsoft.Extensions.Hosting             |
+|     | Microsoft.Extensions.Logging             |
+| **Microsoft.NET.Sdk.Worker**
+|     | Microsoft.Extensions.Configuration       |
+|     | Microsoft.Extensions.DependencyInjection |
+|     | Microsoft.Extensions.Hosting             |
+|     | Microsoft.Extensions.Logging             |
 
 Although this might sound like a good idea, there are downsides. It turns out
 that with multiple targets enabled (frameworks versions mainly) some of the
@@ -62,9 +63,9 @@ otherwise; just by defining namespaces globally in a file.
 ``` C#
 global using System;
 global using System.Collections.Generic;
-global using System.IO;				
-global using System.Linq;			
-global using System.Net.Http;		
-global using System.Threading;	
+global using System.IO;             
+global using System.Linq;           
+global using System.Net.Http;       
+global using System.Threading;  
 global using System.Threading.Tasks;
 ```

--- a/rules/Proj0003.md
+++ b/rules/Proj0003.md
@@ -31,11 +31,12 @@ following global using statements added to your project implicitly.
 
 Although this might sound like a good idea, there are downsides. It turns out
 that with multiple targets enabled (frameworks versions mainly) some of the
-inlcuded namespaces (like `System.Net.Https`) are not even available unless
-a NuGet packages included.
+included namespaces (like `System.Net.Http`) do not exist in your project unless
+a NuGet package is added.
 
-But more importantly, it is a lot of magic that can be archived easily without
-otherwise; just by defining namespaces globally in a file.
+But more importantly, it obscures the dependencies of your project. In addition,
+reducing using statements in your project can be easily achieved by defining
+namespaces globally in a file.
 
 ## Non-compliant
 ``` XML

--- a/rules/Proj0003.md
+++ b/rules/Proj0003.md
@@ -1,0 +1,70 @@
+# Proj0003: Define usings explicit
+
+Once enabled, depending on the type of project you have created you'll have the
+following global using statements added to your project implicitly.
+
+| SDK                      | Default namespaces                       |
+|--------------------------|------------------------------------------|
+| Microsoft.NET.Sdk        | System									  |
+|                          | System.Collections.Generic				  |
+|                          | System.IO								  |
+|                          | System.Linq							  |
+|                          | System.Net.Http						  |
+|                          | System.Threading						  |
+|                          | System.Threading.Tasks					  |
+|--------------------------|------------------------------------------|
+| Microsoft.NET.Sdk.Web    | System.Net.Http.Json					  |
+|                          | Microsoft.AspNetCore.Builder			  |
+|                          | Microsoft.AspNetCore.Hosting			  |
+|                          | Microsoft.AspNetCore.Http				  |
+|                          | Microsoft.AspNetCore.Routing			  |
+|                          | Microsoft.Extensions.Configuration		  |
+|                          | Microsoft.Extensions.DependencyInjection |
+|                          | Microsoft.Extensions.Hosting			  |
+|                          | Microsoft.Extensions.Logging			  |
+|--------------------------|------------------------------------------|
+| Microsoft.NET.Sdk.Worker | Microsoft.Extensions.Configuration		  |
+|                          | Microsoft.Extensions.DependencyInjection |
+|                          | Microsoft.Extensions.Hosting			  |
+|                          | Microsoft.Extensions.Logging			  |
+
+Although this might sound like a good idea, there are downsides. It turns out
+that with multiple targets enabled (frameworks versions mainly) some of the
+inlcuded namespaces (like `System.Net.Https`) are not even available unless
+a NuGet packages included.
+
+But more importantly, it is a lot of magic that can be archived easily without
+otherwise; just by defining namespaces globally in a file.
+
+## Non-compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>
+```
+
+## Complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>
+```
+
+``` C#
+global using System;
+global using System.Collections.Generic;
+global using System.IO;				
+global using System.Linq;			
+global using System.Net.Http;		
+global using System.Threading;	
+global using System.Threading.Tasks;
+```

--- a/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Design_specs;
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
@@ -1,10 +1,15 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using System.Reflection;
 
 namespace Design_specs;
 
 public class Rules
 {
+    [Test]
+    public void Ids_are_unique()
+        => Descriptors.Select(d => d.Id).Should().OnlyHaveUniqueItems();
+
     [TestCaseSource(nameof(Types))]
     public void in_DotNetProjectFile_Analyzers_namespace(Type type)
         => type.Namespace.Should().Be("DotNetProjectFile.Analyzers");
@@ -22,5 +27,11 @@ public class Rules
         => typeof(DotNetProjectFile.ProjectFileAnalyzer).Assembly
         .GetTypes()
         .Where(t => !t.IsAbstract && t.IsAssignableTo(typeof(DiagnosticAnalyzer)));
+
+    public static IEnumerable<DiagnosticDescriptor> Descriptors
+        => typeof(DotNetProjectFile.Rule)
+        .GetFields(BindingFlags.Public | BindingFlags.Static)
+        .Where(f => f.FieldType == typeof(DiagnosticDescriptor))
+        .Select(f => (DiagnosticDescriptor)f.GetValue(null)!);
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Extensions/Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Extensions/Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using CodeAnalysis.TestTools;
-using CodeAnalysis.TestTools.Contexts;
+﻿using CodeAnalysis.TestTools.Contexts;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Extensions/System.Threading.Tasks.Run.Sync.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Extensions/System.Threading.Tasks.Run.Sync.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.Contracts;
-
-namespace System.Threading.Tasks;
+﻿namespace System.Threading.Tasks;
 
 /// <remarks>
 /// Microsoft built an AsyncHelper (internal) class to run Async as Sync.

--- a/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/FindsExtensions.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/FindsExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using CodeAnalysis.TestTools.Contexts;
-using Microsoft.CodeAnalysis;
-using System.Text;
 
 namespace FluentAssertions;
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/Issue.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/Issue.cs
@@ -1,13 +1,24 @@
 ﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 
 namespace FluentAssertions;
 
-internal sealed record Issue(string Id, string Message, DiagnosticSeverity Severity = DiagnosticSeverity.Warning)
+internal sealed record Issue(
+    string Id,
+    string Message, 
+    LinePositionSpan Span = default,
+    DiagnosticSeverity Severity = DiagnosticSeverity.Warning)
 {
+    public Issue WithSpan(int lineStart, int posStart, int lineEnd, int posEnd)
+        => this with
+        {
+            Span = new(new(lineStart, posStart), new(lineEnd, posEnd)),
+        };
+
     public override string ToString() => Severity == DiagnosticSeverity.Warning
-        ? $"{Id} {Message}"
-        : $"{Id} {Message} ({Severity})";
+        ? $"{Id} {Message} ({Span})"
+        : $"{Id} {Message} ({Span}, {Severity})";
 
     public static Issue FromDiagnostic(Diagnostic diagnostic)
-        => new(diagnostic.Id, diagnostic.GetMessage(), diagnostic.Severity);
+        => new(diagnostic.Id, diagnostic.GetMessage(), diagnostic.Location.GetLineSpan().Span, diagnostic.Severity);
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/Issue.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/Issue.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
-using System.Text;
+﻿using Microsoft.CodeAnalysis.Text;
 
 namespace FluentAssertions;
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/Issue.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/Issue.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using System.Text;
 
 namespace FluentAssertions;
 
@@ -15,9 +16,19 @@ internal sealed record Issue(
             Span = new(new(lineStart, posStart), new(lineEnd, posEnd)),
         };
 
-    public override string ToString() => Severity == DiagnosticSeverity.Warning
-        ? $"{Id} {Message} ({Span})"
-        : $"{Id} {Message} ({Span}, {Severity})";
+    public override string ToString()
+    {
+        var sb = new StringBuilder($"{Id} {Message}");
+        if (Span != default)
+        {
+            sb.Append($" @[{Span}]");
+        }
+        if (Severity != DiagnosticSeverity.Warning)
+        {
+            sb.Append($" {Severity}");
+        }
+        return sb.ToString();
+    }
 
     public static Issue FromDiagnostic(Diagnostic diagnostic)
         => new(diagnostic.Id, diagnostic.GetMessage(), diagnostic.Location.GetLineSpan().Span, diagnostic.Severity);

--- a/specs/DotNetProjectFile.Analyzers.Specs/Properties/GlobalUsings.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Properties/GlobalUsings.cs
@@ -1,2 +1,8 @@
+global using CodeAnalysis.TestTools;
+global using DotNetProjectFile.Analyzers;
 global using FluentAssertions;
+global using Microsoft.CodeAnalysis;
+global using Microsoft.CodeAnalysis.Diagnostics;
 global using NUnit.Framework;
+global using System.Diagnostics.Contracts;
+global using System.Text;

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_usings_explicit.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_usings_explicit.cs
@@ -1,8 +1,4 @@
-﻿using CodeAnalysis.TestTools;
-using DotNetProjectFile.Analyzers;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Rules.Define_usings_explicit;
+﻿namespace Rules.Define_usings_explicit;
 
 public class Reports
 {

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_usings_explicit.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_usings_explicit.cs
@@ -11,7 +11,7 @@ public class Reports
         => new DefineUsingsExplicit()
         .ForProject("ImplicitUsings.cs")
         .HasIssue(
-            new Issue("Proj0003", "Define usings explicit.").WithSpan(4, 5, 4, 42));
+            new Issue("Proj0003", "Define usings explicit.").WithSpan(4, 5, 4, 43));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_usings_explicit.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_usings_explicit.cs
@@ -11,7 +11,7 @@ public class Reports
         => new DefineUsingsExplicit()
         .ForProject("ImplicitUsings.cs")
         .HasIssue(
-            new Issue("Proj0003", "Define usings explicit.").WithSpan(4, 6, 4, 43));
+            new Issue("Proj0003", "Define usings explicit.").WithSpan(4, 5, 4, 42));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_usings_explicit.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_usings_explicit.cs
@@ -11,7 +11,7 @@ public class Reports
         => new DefineUsingsExplicit()
         .ForProject("ImplicitUsings.cs")
         .HasIssue(
-            new Issue("Proj0003", "Define usings explicit.").WithSpan(5, 6, 5, 43));
+            new Issue("Proj0003", "Define usings explicit.").WithSpan(4, 6, 4, 43));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_usings_explicit.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_usings_explicit.cs
@@ -1,0 +1,25 @@
+﻿using CodeAnalysis.TestTools;
+using DotNetProjectFile.Analyzers;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Rules.Define_usings_explicit;
+
+public class Reports
+{
+    [Test]
+    public void implicit_usings()
+        => new DefineUsingsExplicit()
+        .ForProject("ImplicitUsings.cs")
+        .HasIssue(
+            new Issue("Proj0003", "Define usings explicit.").WithSpan(5, 6, 5, 43));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    public void Projects_without_issues(string project)
+         => new DefineUsingsExplicit()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Project_file_could_not_be_located.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Project_file_could_not_be_located.cs
@@ -1,8 +1,4 @@
-﻿using CodeAnalysis.TestTools;
-using DotNetProjectFile.Analyzers;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Rules.Project_file_could_not_be_located;
+﻿namespace Rules.Project_file_could_not_be_located;
 
 public class Has_no_issues
 {

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Use_analyzers_for_packages.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Use_analyzers_for_packages.cs
@@ -1,8 +1,4 @@
-﻿using CodeAnalysis.TestTools;
-using DotNetProjectFile.Analyzers;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Rules.Use_analyzers_for_packages;
+﻿namespace Rules.Use_analyzers_for_packages;
 
 #if RELEASE
 [TestFixture(Ignore = "Build has difficulties resolving (some) NuGet packages")]

--- a/src/DotNetProjectFile.Analyzers/Analyzers/DefineUsingsExplicit.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/DefineUsingsExplicit.cs
@@ -1,0 +1,22 @@
+﻿namespace DotNetProjectFile.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class DefineUsingsExplicit : ProjectFileAnalyzer
+{
+    public DefineUsingsExplicit() : base(Rule.DefineUsingsExplicit) { }
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (context.Project.GetSelfAndAccestors()
+            .SelectMany(p => p.PropertyGroups)
+            .SelectMany(g => g.ImplicitUsings)
+            .LastOrDefault(i => IsEnabled(i.Value)) is { } node)
+        {
+            context.ReportDiagnostic(Descriptor, node.Location);
+        }
+    }
+
+    private bool IsEnabled(ImplicitUsings.Kind? implicitUsing)
+        => implicitUsing == ImplicitUsings.Kind.@true
+        || implicitUsing == ImplicitUsings.Kind.enable;
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/DefineUsingsExplicit.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/DefineUsingsExplicit.cs
@@ -7,7 +7,7 @@ public sealed class DefineUsingsExplicit : ProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.Project.GetSelfAndAccestors()
+        if (context.Project.GetSelfAndAncestors()
             .SelectMany(p => p.PropertyGroups)
             .SelectMany(g => g.ImplicitUsings)
             .LastOrDefault(i => IsEnabled(i.Value)) is { } node)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/DefineUsingsExplicit.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/DefineUsingsExplicit.cs
@@ -7,7 +7,7 @@ public sealed class DefineUsingsExplicit : ProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.Project.GetSelfAndAncestors()
+        if (context.Project.AncestorsAndSelf()
             .SelectMany(p => p.PropertyGroups)
             .SelectMany(g => g.ImplicitUsings)
             .LastOrDefault(i => IsEnabled(i.Value)) is { } node)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/ProjectFileCouldNotBeLocated.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/ProjectFileCouldNotBeLocated.cs
@@ -1,7 +1,4 @@
-﻿using DotNetProjectFile.Xml;
-using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace DotNetProjectFile.Analyzers;
+﻿namespace DotNetProjectFile.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class ProjectFileCouldNotBeLocated : ProjectFileAnalyzer

--- a/src/DotNetProjectFile.Analyzers/Analyzers/UseAnalyzersForPackages.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/UseAnalyzersForPackages.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace DotNetProjectFile.Analyzers;
+﻿namespace DotNetProjectFile.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class UseAnalyzersForPackages : ProjectFileAnalyzer
@@ -9,7 +7,7 @@ public sealed class UseAnalyzersForPackages : ProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        var packageReferences = context.Project.GetProjects()
+        var packageReferences = context.Project.GetSelfAndAccestors()
             .SelectMany(p => p.ItemGroups)
             .SelectMany(group => group.PackageReferences)
             .ToArray();
@@ -19,7 +17,7 @@ public sealed class UseAnalyzersForPackages : ProjectFileAnalyzer
             if (packageReferences.None(analyzer.IsMatch)
                 && context.Compilation.ReferencedAssemblyNames.FirstOrDefault(analyzer.IsMatch) is { } reference)
             {
-                context.ReportDiagnostic(Descriptor, analyzer.Package, reference.Name);
+                context.ReportDiagnostic(Descriptor, Location.None, analyzer.Package, reference.Name);
             }
         }
     }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/UseAnalyzersForPackages.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/UseAnalyzersForPackages.cs
@@ -7,7 +7,7 @@ public sealed class UseAnalyzersForPackages : ProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        var packageReferences = context.Project.GetSelfAndAccestors()
+        var packageReferences = context.Project.GetSelfAndAncestors()
             .SelectMany(p => p.ItemGroups)
             .SelectMany(group => group.PackageReferences)
             .ToArray();

--- a/src/DotNetProjectFile.Analyzers/Analyzers/UseAnalyzersForPackages.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/UseAnalyzersForPackages.cs
@@ -7,7 +7,7 @@ public sealed class UseAnalyzersForPackages : ProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        var packageReferences = context.Project.GetSelfAndAncestors()
+        var packageReferences = context.Project.AncestorsAndSelf()
             .SelectMany(p => p.ItemGroups)
             .SelectMany(group => group.PackageReferences)
             .ToArray();

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -31,6 +31,6 @@ public readonly struct ProjectFileAnalysisContext
     }
 
     /// <summary>Reports a diagnostic about the project file.</summary>
-    public void ReportDiagnostic(DiagnosticDescriptor descriptor, params object[] messageArgs)
-        => Report(Diagnostic.Create(descriptor, Location.None, messageArgs));
+    public void ReportDiagnostic(DiagnosticDescriptor descriptor, Location location, params object[] messageArgs)
+        => Report(Diagnostic.Create(descriptor, location, messageArgs));
 }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -19,6 +19,8 @@
     <PackageReleaseNotes>
 v1.0.0
 - Proj0001: .NET project file could not be located.
+- Proj0003: Define usings explicit.
+- Proj1001: Use analyzers for packages.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Text.LinePosition.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Text.LinePosition.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.CodeAnalysis.Text;
+
+public static class LinePositionExtensions
+{
+    public static LinePosition Expand(this LinePosition span, int right)
+        => new(span.Line, span.Character + right);
+}

--- a/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Text.TextSpan.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Text.TextSpan.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.CodeAnalysis.Text;
+
+public static class TextSpanExtensions
+{
+    public static TextSpan TextSpan(this SourceText text, LinePositionSpan span)
+    {
+        var start = text.Lines[span.Start.Line];
+        var end = text.Lines[span.End.Line];
+        return new(start.Start + span.Start.Character, end.Start + span.End.Character);
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.IXmlLineInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.IXmlLineInfo.cs
@@ -9,8 +9,9 @@ public static class XmlLineInfoExtensions
     {
         var start = info.LinePositionStart();
         var end = info is XElement element && element.NextNode is IXmlLineInfo next
-            ? new LinePosition(next.LineNumber - 1, next.LinePosition - 2)
-            : new LinePosition(info.LineNumber - 1, info.LinePosition + 1);
+            ? next.LinePositionStart()
+            : start.Expand(right: +1);
+
         return new(start, end);
     }
 

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.IXmlLineInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.IXmlLineInfo.cs
@@ -9,10 +9,11 @@ public static class XmlLineInfoExtensions
     {
         var start = info.LinePositionStart();
         var end = info is XElement element && element.NextNode is IXmlLineInfo next
-            ? new LinePosition(next.LineNumber - 1, next.LinePosition - 1)
+            ? new LinePosition(next.LineNumber - 1, next.LinePosition - 2)
             : new LinePosition(info.LineNumber - 1, info.LinePosition + 1);
         return new(start, end);
     }
 
-    private static LinePosition LinePositionStart(this IXmlLineInfo info) => new(info.LineNumber - 1, info.LinePosition);
+    private static LinePosition LinePositionStart(this IXmlLineInfo info)
+        => new(info.LineNumber - 1, info.LinePosition - 1);
 }

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.IXmlLineInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.IXmlLineInfo.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.CodeAnalysis.Text;
+using System.Xml.Linq;
+
+namespace System.Xml;
+
+public static class XmlLineInfoExtensions
+{
+    public static LinePositionSpan LinePositionSpan(this IXmlLineInfo info)
+    {
+        var start = info.LinePositionStart();
+        var end = info is XElement element && element.NextNode is IXmlLineInfo next
+            ? new LinePosition(next.LineNumber, next.LinePosition - 1)
+            : new LinePosition(info.LineNumber, info.LinePosition + 1);
+        return new(start, end);
+    }
+
+    private static LinePosition LinePositionStart(this IXmlLineInfo info) => new(info.LineNumber, info.LinePosition);
+}

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.IXmlLineInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.IXmlLineInfo.cs
@@ -9,10 +9,10 @@ public static class XmlLineInfoExtensions
     {
         var start = info.LinePositionStart();
         var end = info is XElement element && element.NextNode is IXmlLineInfo next
-            ? new LinePosition(next.LineNumber, next.LinePosition - 1)
-            : new LinePosition(info.LineNumber, info.LinePosition + 1);
+            ? new LinePosition(next.LineNumber - 1, next.LinePosition - 1)
+            : new LinePosition(info.LineNumber - 1, info.LinePosition + 1);
         return new(start, end);
     }
 
-    private static LinePosition LinePositionStart(this IXmlLineInfo info) => new(info.LineNumber, info.LinePosition);
+    private static LinePosition LinePositionStart(this IXmlLineInfo info) => new(info.LineNumber - 1, info.LinePosition);
 }

--- a/src/DotNetProjectFile.Analyzers/Properties/GlobalUsings.cs
+++ b/src/DotNetProjectFile.Analyzers/Properties/GlobalUsings.cs
@@ -1,5 +1,7 @@
 ﻿global using DotNetProjectFile.Diagnostics;
+global using DotNetProjectFile.Xml;
 global using Microsoft.CodeAnalysis;
+global using Microsoft.CodeAnalysis.Diagnostics;
 global using System;
 global using System.Collections;
 global using System.Collections.Generic;

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -3,4 +3,5 @@ The package contains analyzers that analyze .NET project files.
 
 ## Rules
 * [**Proj0001** .NET project file could not be located](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0001.md)
-* [**Proj1001** "Use analyzers for packages](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1001.md)
+* [**Proj0003** Define usings explicit](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0003.md)
+* [**Proj1001** Use analyzers for packages](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1001.md)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -14,6 +14,18 @@ public static class Rule
         severity: DiagnosticSeverity.Warning,
         isEnabled: true);
 
+    public static DiagnosticDescriptor DefineUsingsExplicit => New(
+        id: 0003,
+        title: "Define usings explicit",
+        message: "Define usings explicit.",
+        description:
+            "The included namespaces should be clear. To reduce the statements " +
+            "per file, consider global using statements.",
+        tags: new[] { "Configuration", "usings", "global" },
+        category: Category.Clarity,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
     public static DiagnosticDescriptor UseAnalyzersForPackages => New(
         id: 1001,
         title: "Use analyzers for packages",

--- a/src/DotNetProjectFile.Analyzers/Xml/ImplicitUsings.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/ImplicitUsings.cs
@@ -1,0 +1,17 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Xml;
+
+public sealed class ImplicitUsings : Node
+{
+    public enum Kind
+    {
+        disable,
+        enable,
+        @true,
+    }
+
+    public ImplicitUsings(XElement element, Project project) : base(element, project) { }
+
+    public Kind? Value => Convert<Kind?>(Element.Value);
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/Import.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Import.cs
@@ -4,7 +4,7 @@ namespace DotNetProjectFile.Xml;
 
 public sealed class Import : Node
 {
-    public Import(XElement element) : base(element) { }
+    public Import(XElement element, Project project) : base(element, project) { }
 
     public string? Project => GetAttribute();
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/Import.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Import.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Linq;
+﻿using System.IO;
+using System.Xml.Linq;
 
 namespace DotNetProjectFile.Xml;
 
@@ -6,5 +7,28 @@ public sealed class Import : Node
 {
     public Import(XElement element, Project project) : base(element, project) { }
 
-    public string? Project => GetAttribute();
+    public Project? Value
+    {
+        get
+        {
+            if (!init)
+            {
+                value = GetValue();
+                init = true;
+            }
+            return value;
+        }
+    }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private Project? value;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private bool init;
+
+    private Project? GetValue()
+    {
+        var location = new FileInfo(Path.Combine(Project.Path.Directory.FullName, GetAttribute("Project")));
+        return Project.Projects.TryResolve(location);
+    }
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/ItemGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/ItemGroup.cs
@@ -20,7 +20,7 @@ public sealed class ItemGroup : Node
     /// <param name="element">
     /// The corresponding <see cref="XElement"/>.
     /// </param>
-    public ItemGroup(XElement element) : base(element) { }
+    public ItemGroup(XElement element, Project project) : base(element, project) { }
 
     /// <summary>Gets the child package references.</summary>
     public Nodes<PackageReference> PackageReferences => GetChildren<PackageReference>();

--- a/src/DotNetProjectFile.Analyzers/Xml/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Node.cs
@@ -1,7 +1,9 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.IO;
+using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Linq;
 using DotNetProjectFile.Xml.Conversion;
+using Microsoft.CodeAnalysis.Text;
 
 namespace DotNetProjectFile.Xml;
 
@@ -9,9 +11,15 @@ namespace DotNetProjectFile.Xml;
 public class Node
 {
     /// <summary>Initializes a new instance of the <see cref="Node"/> class.</summary>
-    protected Node(XElement element) => Element = element;
+    protected Node(XElement element, Project? project)
+    {
+        Element = element;
+        Project = project ?? (this as Project) ?? throw new ArgumentNullException(nameof(project));
+    }
 
-    internal XElement Element { get; }
+    internal readonly XElement Element;
+
+    internal readonly Project Project;
 
     /// <summary>Gets the local name of the <see cref="Node"/>.</summary>
     public virtual string LocalName => GetType().Name;
@@ -21,6 +29,28 @@ public class Node
 
     /// <summary>Get the line info.</summary>
     public IXmlLineInfo LineInfo => Element;
+
+    public int Length => ToString().Length;
+
+    public Location Location => location ??= GetLocation();
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private Location? location;
+
+    private Location GetLocation()
+    {
+        if (Project.SourceText is { })
+        {
+            var path = Project.Path.FullName;
+            var linePositionSpan = LineInfo.LinePositionSpan();
+            var textSpan = Project.SourceText.TextSpan(linePositionSpan);
+            return Location.Create(path, textSpan, linePositionSpan);
+        }
+        else
+        {
+            return Location.None;
+        }
+    }
 
     /// <summary>Represents the node as an <see cref="string"/>.</summary>
     /// <remarks>
@@ -51,18 +81,19 @@ public class Node
     internal IEnumerable<Node> GetAllChildren()
         => Element.Elements().Select(Create).OfType<Node>();
 
-    internal static Node? Create(XElement element)
+    internal Node? Create(XElement element)
     => element.Name.LocalName switch
     {
         null => null,
-        nameof(Import) /*.................*/ => new Import(element),
-        nameof(ItemGroup) /*..............*/ => new ItemGroup(element),
-        nameof(PackageReference) /*.......*/ => new PackageReference(element),
-        nameof(PropertyGroup) /*..........*/ => new PropertyGroup(element),
-        _ => new Unknown(element),
+        nameof(ImplicitUsings) /*.........*/ => new ImplicitUsings(element, Project),
+        nameof(Import) /*.................*/ => new Import(element, Project),
+        nameof(ItemGroup) /*..............*/ => new ItemGroup(element, Project),
+        nameof(PackageReference) /*.......*/ => new PackageReference(element, Project),
+        nameof(PropertyGroup) /*..........*/ => new PropertyGroup(element, Project),
+        _ => new Unknown(element, Project),
     };
 
-    private T? Convert<T>(string? value, string? propertyName)
+    protected T? Convert<T>(string? value, [CallerMemberName] string? propertyName = null)
         => Converters.TryConvert<T>(value, GetType(), propertyName!);
 
     private static readonly TypeConverters Converters = new();

--- a/src/DotNetProjectFile.Analyzers/Xml/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Node.cs
@@ -39,17 +39,10 @@ public class Node
 
     private Location GetLocation()
     {
-        if (Project.SourceText is { })
-        {
-            var path = Project.Path.FullName;
-            var linePositionSpan = LineInfo.LinePositionSpan();
-            var textSpan = Project.SourceText.TextSpan(linePositionSpan);
-            return Location.Create(path, textSpan, linePositionSpan);
-        }
-        else
-        {
-            return Location.None;
-        }
+        var path = Project.Path.FullName;
+        var linePositionSpan = LineInfo.LinePositionSpan();
+        var textSpan = Project.Text.TextSpan(linePositionSpan);
+        return Location.Create(path, textSpan, linePositionSpan);
     }
 
     /// <summary>Represents the node as an <see cref="string"/>.</summary>

--- a/src/DotNetProjectFile.Analyzers/Xml/PackageReference.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/PackageReference.cs
@@ -4,9 +4,7 @@ namespace DotNetProjectFile.Xml;
 
 public sealed class PackageReference : Node
 {
-    public PackageReference(XElement element) : base(element)
-    {
-    }
+    public PackageReference(XElement element, Project project) : base(element, project) { }
 
     public string? Include => GetAttribute();
 

--- a/src/DotNetProjectFile.Analyzers/Xml/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Project.cs
@@ -15,7 +15,7 @@ public sealed class Project : Node
 
     public FileInfo Path { get; }
 
-    private readonly Projects Projects;
+    internal readonly Projects Projects;
 
     internal readonly SourceText? SourceText;
 
@@ -25,14 +25,13 @@ public sealed class Project : Node
 
     public Nodes<ItemGroup> ItemGroups => GetChildren<ItemGroup>();
 
-    public IEnumerable<Project> GetSelfAndAccestors()
+    public IEnumerable<Project> GetSelfAndAncestors()
     {
         foreach (var import in Imports)
         {
-            var location = new FileInfo(System.IO.Path.Combine(Path.Directory.FullName, import.Project));
-            if (Projects.TryResolve(location) is { } project)
+            if (import.Value is { } project)
             {
-                foreach (var p in project.GetSelfAndAccestors())
+                foreach (var p in project.GetSelfAndAncestors())
                 {
                     yield return p;
                 }

--- a/src/DotNetProjectFile.Analyzers/Xml/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Project.cs
@@ -1,19 +1,23 @@
-﻿using System.IO;
+﻿using Microsoft.CodeAnalysis.Text;
+using System.IO;
 using System.Xml.Linq;
 
 namespace DotNetProjectFile.Xml;
 
 public sealed class Project : Node
 {
-    public Project(XElement element, FileInfo location, Projects projects) : base(element)
+    private Project(XElement element, FileInfo path, SourceText? sourceText, Projects projects) : base(element, null!)
     {
-        Location = location;
+        Path = path;
+        SourceText = sourceText;
         Projects = projects;
     }
 
-    public FileInfo Location { get; }
+    public FileInfo Path { get; }
 
     private readonly Projects Projects;
+
+    internal readonly SourceText? SourceText;
 
     public Nodes<Import> Imports => GetChildren<Import>();
 
@@ -21,14 +25,14 @@ public sealed class Project : Node
 
     public Nodes<ItemGroup> ItemGroups => GetChildren<ItemGroup>();
 
-    public IEnumerable<Project> GetProjects()
+    public IEnumerable<Project> GetSelfAndAccestors()
     {
         foreach (var import in Imports)
         {
-            var location = new FileInfo(Path.Combine(Location.Directory.FullName, import.Project));
+            var location = new FileInfo(System.IO.Path.Combine(Path.Directory.FullName, import.Project));
             if (Projects.TryResolve(location) is { } project)
             {
-                foreach (var p in project.GetProjects())
+                foreach (var p in project.GetSelfAndAccestors())
                 {
                     yield return p;
                 }
@@ -38,12 +42,20 @@ public sealed class Project : Node
     }
 
     public static Project Load(FileInfo file, Projects projects) => new(
-        XElement.Load(file.OpenRead(), LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo),
+        XElement.Load(file.OpenRead(), LoadOptions),
         file,
+        null,
         projects);
 
-    internal static Project Load(AdditionalText text, Projects projects) => new(
-        XElement.Parse(text.GetText()?.ToString()),
-        new(text.Path),
-        projects);
+    internal static Project Load(AdditionalText text, Projects projects)
+    {
+        var sourcText = text.GetText()!;
+        return new(
+            XElement.Parse(sourcText.ToString(), LoadOptions),
+            new(text.Path),
+            sourcText,
+            projects);
+    }
+
+    private static readonly LoadOptions LoadOptions = LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo;
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Project.cs
@@ -26,13 +26,13 @@ public sealed class Project : Node
 
     public Nodes<ItemGroup> ItemGroups => GetChildren<ItemGroup>();
 
-    public IEnumerable<Project> GetSelfAndAncestors()
+    public IEnumerable<Project> AncestorsAndSelf()
     {
         foreach (var import in Imports)
         {
             if (import.Value is { } project)
             {
-                foreach (var p in project.GetSelfAndAncestors())
+                foreach (var p in project.AncestorsAndSelf())
                 {
                     yield return p;
                 }

--- a/src/DotNetProjectFile.Analyzers/Xml/Projects.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Projects.cs
@@ -31,6 +31,8 @@ public sealed class Projects
             else if (AdditionalTexts.TryGetValue(location, out var additional)
                 && IsProject(location))
             {
+                var line = additional.GetText()!.Lines[0];
+                var loc = Location.Create(location.FullName, line.Span, default);
                 project = Project.Load(additional, this);
                 Resolved[location] = project;
                 return project;

--- a/src/DotNetProjectFile.Analyzers/Xml/Projects.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Projects.cs
@@ -31,8 +31,6 @@ public sealed class Projects
             else if (AdditionalTexts.TryGetValue(location, out var additional)
                 && IsProject(location))
             {
-                var line = additional.GetText()!.Lines[0];
-                var loc = Location.Create(location.FullName, line.Span, default);
                 project = Project.Load(additional, this);
                 Resolved[location] = project;
                 return project;

--- a/src/DotNetProjectFile.Analyzers/Xml/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/PropertyGroup.cs
@@ -4,17 +4,10 @@ namespace DotNetProjectFile.Xml;
 
 public sealed class PropertyGroup : Node
 {
-    public enum ImplicitUsingKind
-    {
-        disable,
-        enable,
-        @true,
-    }
-
     /// <summary>Initializes a new instance of the <see cref="PropertyGroup"/> class.</summary>
-    public PropertyGroup(XElement element) : base(element) { }
+    public PropertyGroup(XElement element, Project project) : base(element, project) { }
 
-    public ImplicitUsingKind? ImplicitUsings => GetNode<ImplicitUsingKind?>();
+    public Nodes<ImplicitUsings> ImplicitUsings => GetChildren<ImplicitUsings>();
 
     public NullableContextOptions? Nullable => GetNode<NullableContextOptions?>();
 

--- a/src/DotNetProjectFile.Analyzers/Xml/Unknown.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Unknown.cs
@@ -9,7 +9,7 @@ public sealed class Unknown : Node
     /// <param name="element">
     /// The corresponding <see cref="XElement"/>.
     /// </param>
-    public Unknown(XElement element) : base(element) { }
+    public Unknown(XElement element, Project project) : base(element, project) { }
 
     /// <summary>Gets the local name of the <see cref="Unknown"/>.</summary>
     public override string LocalName => Element.Name.LocalName;


### PR DESCRIPTION
# Define usings explicit

Once enabled, depending on the type of project you have created you'll have the
following global using statements added to your project implicitly.

| SDK | Default namespaces                       |
|-----|------------------------------------------|
| **Microsoft.NET.Sdk**
|     | System                                   |
|     | System.Collections.Generic               |
|     | System.IO                                |
|     | System.Linq                              |
|     | System.Net.Http                          |
|     | System.Threading                         |
|     | System.Threading.Tasks                   |
| **Microsoft.NET.Sdk.Web**
|     | System.Net.Http.Json                     |
|     | Microsoft.AspNetCore.Builder             |
|     | Microsoft.AspNetCore.Hosting             |
|     | Microsoft.AspNetCore.Http                |
|     | Microsoft.AspNetCore.Routing             |
|     | Microsoft.Extensions.Configuration       |
|     | Microsoft.Extensions.DependencyInjection |
|     | Microsoft.Extensions.Hosting             |
|     | Microsoft.Extensions.Logging             |
| **Microsoft.NET.Sdk.Worker**
|     | Microsoft.Extensions.Configuration       |
|     | Microsoft.Extensions.DependencyInjection |
|     | Microsoft.Extensions.Hosting             |
|     | Microsoft.Extensions.Logging             |

Although this might sound like a good idea, there are downsides. It turns out
that with multiple targets enabled (frameworks versions mainly) some of the
inlcuded namespaces (like `System.Net.Https`) are not even available unless
a NuGet packages included.

But more importantly, it is a lot of magic that can be archived easily without
otherwise; just by defining namespaces globally in a file.