### PR TITLE
New Rule Proj0004: Run NuGet security audits automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ In a props file:
 * [**Proj0001** .NET project file could not be located](rules/Proj0001.md)
 * [**Proj0002** Upgrade legacy .NET project files](rules/Proj0002.md)
 * [**Proj0003** Define usings explicit](rules/Proj0003.md)
+* [**Proj0004** Run NuGet security audits automatically](rules/Proj0004.md)
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
 
 ## Reference an analyzer from a project

--- a/build.sln
+++ b/build.sln
@@ -17,6 +17,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NoAdditionalFiles", "projec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitUsings", "projects\ImplicitUsings\ImplicitUsings.csproj", "{D525C7B7-5B0B-489D-BC3E-968597F84A58}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NoNugetAudit", "projects\NoNugetAudit\NoNugetAudit.csproj", "{909DAEE9-592F-4FA5-8777-CCDB563D0B49}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DisabledNugetAudit", "projects\DisabledNugetAudit\DisabledNugetAudit.csproj", "{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +51,14 @@ Global
 		{D525C7B7-5B0B-489D-BC3E-968597F84A58}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D525C7B7-5B0B-489D-BC3E-968597F84A58}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D525C7B7-5B0B-489D-BC3E-968597F84A58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{909DAEE9-592F-4FA5-8777-CCDB563D0B49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{909DAEE9-592F-4FA5-8777-CCDB563D0B49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{909DAEE9-592F-4FA5-8777-CCDB563D0B49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{909DAEE9-592F-4FA5-8777-CCDB563D0B49}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -56,6 +68,8 @@ Global
 		{74F59396-7A67-474A-A404-97B038C237F3} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{9B0241FD-A840-41AB-BE7E-BB3512CEA2D0} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{D525C7B7-5B0B-489D-BC3E-968597F84A58} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{909DAEE9-592F-4FA5-8777-CCDB563D0B49} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -24,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj0001.md = rules\Proj0001.md
 		rules\Proj0002.md = rules\Proj0002.md
 		rules\Proj0003.md = rules\Proj0003.md
+		rules\Proj0004.md = rules\Proj0004.md
 		rules\Proj1001.md = rules\Proj1001.md
 	EndProjectSection
 EndProject
@@ -52,6 +53,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitUsings", "projects\ImplicitUsings\ImplicitUsings.csproj", "{64D2404F-D04E-4926-8503-0D0C97C1EDBC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyProject", "projects\LegacyProject\LegacyProject.csproj", "{ECC1C67A-4BD7-400F-92C5-39395F05B586}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NoNugetAudit", "projects\NoNugetAudit\NoNugetAudit.csproj", "{C87CBF4B-8F0F-4C25-9AD5-4B1230FE117C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DisabledNugetAudit", "projects\DisabledNugetAudit\DisabledNugetAudit.csproj", "{572E6913-ABC2-4CAF-9F11-1C41770473C2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -95,6 +100,14 @@ Global
 		{ECC1C67A-4BD7-400F-92C5-39395F05B586}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ECC1C67A-4BD7-400F-92C5-39395F05B586}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ECC1C67A-4BD7-400F-92C5-39395F05B586}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C87CBF4B-8F0F-4C25-9AD5-4B1230FE117C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C87CBF4B-8F0F-4C25-9AD5-4B1230FE117C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C87CBF4B-8F0F-4C25-9AD5-4B1230FE117C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C87CBF4B-8F0F-4C25-9AD5-4B1230FE117C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{572E6913-ABC2-4CAF-9F11-1C41770473C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{572E6913-ABC2-4CAF-9F11-1C41770473C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{572E6913-ABC2-4CAF-9F11-1C41770473C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{572E6913-ABC2-4CAF-9F11-1C41770473C2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,6 +123,8 @@ Global
 		{00669DF6-1449-41AA-8AD3-FA84194CE5B4} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{64D2404F-D04E-4926-8503-0D0C97C1EDBC} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{ECC1C67A-4BD7-400F-92C5-39395F05B586} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{C87CBF4B-8F0F-4C25-9AD5-4B1230FE117C} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{572E6913-ABC2-4CAF-9F11-1C41770473C2} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/CompliantCSharp/CompliantCSharp.csproj
+++ b/projects/CompliantCSharp/CompliantCSharp.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
+    <NuGetAudit>true</NuGetAudit>
   </PropertyGroup>
   
   <ItemGroup>

--- a/projects/CompliantVB/CompliantVB.vbproj
+++ b/projects/CompliantVB/CompliantVB.vbproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RootNamespace>CompliantVB</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <NuGetAudit>true</NuGetAudit>
     <OptionStrict>On</OptionStrict>
   </PropertyGroup>
 

--- a/projects/DisabledNugetAudit/DisabledNugetAudit.csproj
+++ b/projects/DisabledNugetAudit/DisabledNugetAudit.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+
+</Project>

--- a/projects/DisabledNugetAudit/Placeholder.cs
+++ b/projects/DisabledNugetAudit/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace DisabledNugetAudit;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/projects/NoNugetAudit/NoNugetAudit.csproj
+++ b/projects/NoNugetAudit/NoNugetAudit.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/projects/NoNugetAudit/Placeholder.cs
+++ b/projects/NoNugetAudit/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace NoNugetAudit;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/rules/Proj0004.md
+++ b/rules/Proj0004.md
@@ -1,0 +1,29 @@
+# Proj0004: Run NuGet security audits automatically
+
+Once enabled, GitHub's vulnerability database is consulted to check for security
+issues that come with using any of the referenced packages.
+
+More information: https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages
+
+## Non-compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>
+```
+
+## Complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <NuGetAudit>true</NuGetAudit>
+  </PropertyGroup>
+
+</Project>
+```

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Run_NuGet_security_audits_automatically.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Run_NuGet_security_audits_automatically.cs
@@ -1,0 +1,28 @@
+﻿namespace Rules.Run_NuGet_security_audits_automatically;
+
+public class Reports
+{
+    [Test]
+    public void on_disabled_NuGet_audit()
+       => new RunNuGetSecurityAuditsAutomatically()
+       .ForProject("DisabledNuGetAudit.cs")
+       .HasIssue(
+           new Issue("Proj0004", "Run NuGet security audits automatically.").WithSpan(0, 1, 0, 2));
+
+    [Test]
+    public void on_not_configured_NuGet_audit()
+        => new RunNuGetSecurityAuditsAutomatically()
+        .ForProject("NoNugetAudit.cs")
+        .HasIssue(
+            new Issue("Proj0004", "Run NuGet security audits automatically.").WithSpan(0, 1, 0, 2));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    public void Projects_without_issues(string project)
+         => new RunNuGetSecurityAuditsAutomatically()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Run_NuGet_security_audits_automatically.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Run_NuGet_security_audits_automatically.cs
@@ -5,7 +5,7 @@ public class Reports
     [Test]
     public void on_disabled_NuGet_audit()
        => new RunNuGetSecurityAuditsAutomatically()
-       .ForProject("DisabledNuGetAudit.cs")
+       .ForProject("DisabledNugetAudit.cs")
        .HasIssue(
            new Issue("Proj0004", "Run NuGet security audits automatically.").WithSpan(0, 1, 0, 2));
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/RunNuGetSecurityAuditsAutomatically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/RunNuGetSecurityAuditsAutomatically.cs
@@ -1,0 +1,19 @@
+﻿namespace DotNetProjectFile.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class RunNuGetSecurityAuditsAutomatically : ProjectFileAnalyzer
+{
+    public RunNuGetSecurityAuditsAutomatically() : base(Rule.RunNuGetSecurityAudit) { }
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        var audits = context.Project.AncestorsAndSelf()
+          .SelectMany(p => p.PropertyGroups)
+          .SelectMany(g => g.NuGetAudits);
+
+        if (audits.None() || audits.Any(a => a.Value != true))
+        {
+            context.ReportDiagnostic(Descriptor, context.Project.Location);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/Category.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/Category.cs
@@ -7,4 +7,5 @@ public enum Category
     Configuration,
     Reliability,
     Obsolete,
+    Security,
 }

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.Linq.Enumerable.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.Linq.Enumerable.cs
@@ -2,6 +2,9 @@
 
 internal static class EnumerableExtensions
 {
+    public static bool None<T>(this IEnumerable<T> enumerable)
+        => !enumerable.Any();
+
     public static bool None<T>(this IEnumerable<T> enumerable, Func<T, bool> predicate)
         => !enumerable.Any(predicate);
 }

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -5,4 +5,5 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0001** .NET project file could not be located](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0001.md)
 * [**Proj0002** Upgrade legacy .NET project files](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0002.md)
 * [**Proj0003** Define usings explicit](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0003.md)
+* [**Proj0004** Run NuGet security audits automatically](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0004.md)
 * [**Proj1001** Use analyzers for packages](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1001.md)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -18,7 +18,7 @@ public static class Rule
         id: 0002,
         title: "Upgrade legacy .NET project files",
         message: "Upgrade legacy .NET project file.",
-        description: "In order to make these rules work, the project file should be located.",
+        description: ".NET legacy projects are not supported.",
         tags: new[] { "project file", "legacy", "obsolete" },
         category: Category.Obsolete,
         severity: DiagnosticSeverity.Warning,
@@ -33,6 +33,18 @@ public static class Rule
             "per file, consider global using statements.",
         tags: new[] { "Configuration", "usings", "global" },
         category: Category.Clarity,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
+    public static DiagnosticDescriptor RunNuGetSecurityAudit => New(
+        id: 0004,
+        title: "Run NuGet security audits automatically",
+        message: "Run NuGet security audits automatically.",
+        description:
+            "To reduce security issues, NuGets security audit should be run on " +
+            "every build automatically.",
+        tags: new[] { "security", "NuGet", "vulnerability" },
+        category: Category.Security,
         severity: DiagnosticSeverity.Warning,
         isEnabled: true);
 

--- a/src/DotNetProjectFile.Analyzers/Xml/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Node.cs
@@ -81,6 +81,7 @@ public class Node
         nameof(ImplicitUsings) /*.........*/ => new ImplicitUsings(element, Project),
         nameof(Import) /*.................*/ => new Import(element, Project),
         nameof(ItemGroup) /*..............*/ => new ItemGroup(element, Project),
+        nameof(NuGetAudit) /*.............*/ => new NuGetAudit(element, Project),
         nameof(PackageReference) /*.......*/ => new PackageReference(element, Project),
         nameof(PropertyGroup) /*..........*/ => new PropertyGroup(element, Project),
         _ => new Unknown(element, Project),

--- a/src/DotNetProjectFile.Analyzers/Xml/NuGetAudit.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/NuGetAudit.cs
@@ -1,0 +1,10 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Xml;
+
+public sealed class NuGetAudit : Node
+{
+    public NuGetAudit(XElement element, Project? project) : base(element, project) { }
+
+    public bool? Value => Convert<bool?>(Element.Value);
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/PropertyGroup.cs
@@ -9,7 +9,7 @@ public sealed class PropertyGroup : Node
 
     public Nodes<ImplicitUsings> ImplicitUsings => GetChildren<ImplicitUsings>();
 
-    public NullableContextOptions? Nullable => GetNode<NullableContextOptions?>();
+    public Nodes<NuGetAudit> NuGetAudits => GetChildren<NuGetAudit>();
 
     public string? RootNamespace => GetNode();
 }


### PR DESCRIPTION
# Proj0004: Run NuGet security audits automatically

Once enabled, GitHub's vulnerability database is consulted to check for security issues that come with using any of the referenced packages.

More information: https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages

## Non-compliant
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net7.0</TargetFramework>
  </PropertyGroup>

</Project>
```

## Complaint
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net7.0</TargetFramework>
    <NuGetAudit>true</NuGetAudit>
  </PropertyGroup>

</Project>
```
