### PR TITLE
New Rule Proj0005: Define package reference assets as attributes

### DIFF
--- a/build.sln
+++ b/build.sln
@@ -21,6 +21,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NoNugetAudit", "projects\No
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DisabledNugetAudit", "projects\DisabledNugetAudit\DisabledNugetAudit.csproj", "{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackageReferenceAssetsAsAttributes", "projects\PackageReferenceAssetsAsAttributes\PackageReferenceAssetsAsAttributes.csproj", "{9520C36F-17D6-469B-BD02-4DBBA5B52C26}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackageReferenceAssetsAsElements", "projects\PackageReferenceAssetsAsElements\PackageReferenceAssetsAsElements.csproj", "{7BB4BE09-DAEE-4A39-B64C-772A76B17D86}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +63,14 @@ Global
 		{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9520C36F-17D6-469B-BD02-4DBBA5B52C26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9520C36F-17D6-469B-BD02-4DBBA5B52C26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9520C36F-17D6-469B-BD02-4DBBA5B52C26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9520C36F-17D6-469B-BD02-4DBBA5B52C26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BB4BE09-DAEE-4A39-B64C-772A76B17D86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BB4BE09-DAEE-4A39-B64C-772A76B17D86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BB4BE09-DAEE-4A39-B64C-772A76B17D86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BB4BE09-DAEE-4A39-B64C-772A76B17D86}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -70,6 +82,8 @@ Global
 		{D525C7B7-5B0B-489D-BC3E-968597F84A58} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{909DAEE9-592F-4FA5-8777-CCDB563D0B49} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{3083F5F4-2C49-4AE2-8CED-49F1DA0E7691} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{9520C36F-17D6-469B-BD02-4DBBA5B52C26} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{7BB4BE09-DAEE-4A39-B64C-772A76B17D86} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -25,6 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj0002.md = rules\Proj0002.md
 		rules\Proj0003.md = rules\Proj0003.md
 		rules\Proj0004.md = rules\Proj0004.md
+		rules\Proj0005.md = rules\Proj0005.md
 		rules\Proj1001.md = rules\Proj1001.md
 	EndProjectSection
 EndProject
@@ -54,9 +55,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitUsings", "projects\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyProject", "projects\LegacyProject\LegacyProject.csproj", "{ECC1C67A-4BD7-400F-92C5-39395F05B586}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NoNugetAudit", "projects\NoNugetAudit\NoNugetAudit.csproj", "{C87CBF4B-8F0F-4C25-9AD5-4B1230FE117C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NoNugetAudit", "projects\NoNugetAudit\NoNugetAudit.csproj", "{C87CBF4B-8F0F-4C25-9AD5-4B1230FE117C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DisabledNugetAudit", "projects\DisabledNugetAudit\DisabledNugetAudit.csproj", "{572E6913-ABC2-4CAF-9F11-1C41770473C2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DisabledNugetAudit", "projects\DisabledNugetAudit\DisabledNugetAudit.csproj", "{572E6913-ABC2-4CAF-9F11-1C41770473C2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageReferenceAssetsAsElements", "projects\PackageReferenceAssetsAsElements\PackageReferenceAssetsAsElements.csproj", "{A9BAF667-0043-45A5-9B8C-941C524B32CE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageReferenceAssetsAsAttributes", "projects\PackageReferenceAssetsAsAttributes\PackageReferenceAssetsAsAttributes.csproj", "{FD32A616-69E1-4313-8CD9-36B6089AC84A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -108,6 +113,14 @@ Global
 		{572E6913-ABC2-4CAF-9F11-1C41770473C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{572E6913-ABC2-4CAF-9F11-1C41770473C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{572E6913-ABC2-4CAF-9F11-1C41770473C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9BAF667-0043-45A5-9B8C-941C524B32CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9BAF667-0043-45A5-9B8C-941C524B32CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9BAF667-0043-45A5-9B8C-941C524B32CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9BAF667-0043-45A5-9B8C-941C524B32CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD32A616-69E1-4313-8CD9-36B6089AC84A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD32A616-69E1-4313-8CD9-36B6089AC84A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD32A616-69E1-4313-8CD9-36B6089AC84A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD32A616-69E1-4313-8CD9-36B6089AC84A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -125,6 +138,8 @@ Global
 		{ECC1C67A-4BD7-400F-92C5-39395F05B586} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{C87CBF4B-8F0F-4C25-9AD5-4B1230FE117C} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{572E6913-ABC2-4CAF-9F11-1C41770473C2} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{A9BAF667-0043-45A5-9B8C-941C524B32CE} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{FD32A616-69E1-4313-8CD9-36B6089AC84A} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/LegacyProject/LegacyProject.csproj
+++ b/projects/LegacyProject/LegacyProject.csproj
@@ -7,6 +7,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LegacyProject</RootNamespace>
     <AssemblyName>LegacyProject</AssemblyName>
+    <AseemblyVersion>0.0.1</AseemblyVersion>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/projects/PackageReferenceAssetsAsAttributes/PackageReferenceAssetsAsAttributes.csproj
+++ b/projects/PackageReferenceAssetsAsAttributes/PackageReferenceAssetsAsAttributes.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="BackwardsCompatibleFeatures" Version="2.*" />
+    <PackageReference Include="Qowaiv" Version="6.4.1">
+      <NoWarn>Proj0001</NoWarn>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/projects/PackageReferenceAssetsAsAttributes/Placeholder.cs
+++ b/projects/PackageReferenceAssetsAsAttributes/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace PackageReferenceAssetsAsAttributes;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/projects/PackageReferenceAssetsAsElements/PackageReferenceAssetsAsElements.csproj
+++ b/projects/PackageReferenceAssetsAsElements/PackageReferenceAssetsAsElements.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BackwardsCompatibleFeatures" Version="2.*">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/projects/PackageReferenceAssetsAsElements/Placeholder.cs
+++ b/projects/PackageReferenceAssetsAsElements/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace PackageReferenceAssetsAsElements;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/rules/Proj0005.md
+++ b/rules/Proj0005.md
@@ -1,0 +1,25 @@
+# Proj0005: Define package reference assets as attributes
+
+## Non-compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup Label="Analyzer">
+    <ProjectReference Include="DotNetProjectFile.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+  </ItemGroup>
+
+</Project>
+```
+
+## Complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup Label="Analyzer">
+    <ProjectReference Include="DotNetProjectFile.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+  </ItemGroup>
+
+</Project>
+```

--- a/rules/Proj0005.md
+++ b/rules/Proj0005.md
@@ -1,4 +1,8 @@
 # Proj0005: Define package reference assets as attributes
+You might want to control the [dependency assets](https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets)
+of the package reference, and define its preferences. For readability purposes,
+it is preferred to define `PrivateAssets`, `IncludeAssets`, and `PrivateAsssets`
+as XML attributes, instead of XML elements.
 
 ## Non-compliant
 ``` XML

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_package_reference_assets_as_attributes.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_package_reference_assets_as_attributes.cs
@@ -1,0 +1,23 @@
+﻿namespace Rules.Define_package_reference_assets_as_attributes;
+
+public class Reports
+{
+    [Test]
+    public void assets_as_elements()
+        => new DefinePackageReferenceAssetsAsAttributes()
+        .ForProject("PackageReferenceAssetsAsElements.cs")
+        .HasIssues(
+            new Issue("Proj0005", "Define package reference assets of 'BackwardsCompatibleFeatures' as attributes.").WithSpan(8, 5, 10, 23),
+            new Issue("Proj0005", "Define package reference assets of 'SonarAnalyzer.CSharp' as attributes.").WithSpan(11, 5, 14, 23));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    [TestCase("PackageReferenceAssetsAsAttributes.cs")]
+    public void assets_as_attributes_or_without(string project)
+         => new DefinePackageReferenceAssetsAsAttributes()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/DefinePackageReferenceAssetsAsAttributes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/DefinePackageReferenceAssetsAsAttributes.cs
@@ -1,0 +1,22 @@
+﻿namespace DotNetProjectFile.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class DefinePackageReferenceAssetsAsAttributes : ProjectFileAnalyzer
+{
+    public DefinePackageReferenceAssetsAsAttributes() : base(Rule.DefinePackageReferenceAssetsAsAttributes) { }
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        foreach (var reference in context.Project.AncestorsAndSelf()
+            .SelectMany(p => p.ItemGroups)
+            .SelectMany(g => g.PackageReferences)
+            .Where(HasAssetsElement))
+        {
+            context.ReportDiagnostic(Descriptor, reference.Location, reference.Include);
+        }
+    }
+
+    private bool HasAssetsElement(PackageReference reference)
+        => reference.Element.Elements()
+        .Any(e => e.Name.LocalName.Contains("assets", StringComparison.OrdinalIgnoreCase));
+}

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -31,6 +31,6 @@ public readonly struct ProjectFileAnalysisContext
     }
 
     /// <summary>Reports a diagnostic about the project file.</summary>
-    public void ReportDiagnostic(DiagnosticDescriptor descriptor, Location location, params object[] messageArgs)
+    public void ReportDiagnostic(DiagnosticDescriptor descriptor, Location location, params object?[]? messageArgs)
         => Report(Diagnostic.Create(descriptor, location, messageArgs));
 }

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.String.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.String.cs
@@ -1,0 +1,7 @@
+﻿namespace System;
+
+internal static class StringExtensions
+{
+    public static bool Contains(this string str, string value, StringComparison comparisonType)
+        => str.IndexOf(value, comparisonType) != -1;
+}

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -48,6 +48,18 @@ public static class Rule
         severity: DiagnosticSeverity.Warning,
         isEnabled: true);
 
+    public static DiagnosticDescriptor DefinePackageReferenceAssetsAsAttributes => New(
+        id: 0005,
+        title: "Define package reference assets as attributes",
+        message: "Define package reference assets of '{0}' as attributes.",
+        description:
+            "To reduce security issues, NuGets security audit should be run on " +
+            "every build automatically.",
+        tags: new[] { "security", "NuGet", "vulnerability" },
+        category: Category.Clarity,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
     public static DiagnosticDescriptor UseAnalyzersForPackages => New(
         id: 1001,
         title: "Use analyzers for packages",


### PR DESCRIPTION
# Proj0005: Define package reference assets as attributes
You might want to control the [dependency assets](https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets)
of the package reference, and define its preferences. For readability purposes,
it is preferred to define `PrivateAssets`, `IncludeAssets`, and `PrivateAsssets`
as XML attributes, instead of XML elements.

## Non-compliant
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <ItemGroup Label="Analyzer">
    <ProjectReference Include="DotNetProjectFile.Analyzers">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
  </ItemGroup>

</Project>
```

## Complaint
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <ItemGroup Label="Analyzer">
    <ProjectReference Include="DotNetProjectFile.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
  </ItemGroup>

</Project>
```
