### PR TITLE
New Rule Proj0007: Remove empty nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In a props file:
 * [**Proj0004** Run NuGet security audits automatically](rules/Proj0004.md)
 * [**Proj0005** Define package reference assets as attributes](rules/Proj0005.md)
 * [**Proj0006** Add additional files to improve static code analysis](rules/Proj0006.md)
+* [**Proj0007** Remove empty nodes](rules/Proj0007.md)
 * [**Proj1000** Use the .NET project file analyzers](rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
 

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -28,6 +28,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj0004.md = rules\Proj0004.md
 		rules\Proj0005.md = rules\Proj0005.md
 		rules\Proj0006.md = rules\Proj0006.md
+		rules\Proj0007.md = rules\Proj0007.md
 		rules\Proj1000.md = rules\Proj1000.md
 		rules\Proj1001.md = rules\Proj1001.md
 	EndProjectSection
@@ -49,7 +50,7 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "CompliantVB", "projects\Com
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DisabledNugetAudit", "projects\DisabledNugetAudit\DisabledNugetAudit.csproj", "{572E6913-ABC2-4CAF-9F11-1C41770473C2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmptyProject", "projects\EmptyProject\EmptyProject.csproj", "{F77103CC-4D77-46BE-B62A-22C7691CF858}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EmptyProject", "projects\EmptyProject\EmptyProject.csproj", "{F77103CC-4D77-46BE-B62A-22C7691CF858}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImplicitUsings", "projects\ImplicitUsings\ImplicitUsings.csproj", "{64D2404F-D04E-4926-8503-0D0C97C1EDBC}"
 EndProject
@@ -66,6 +67,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackagesWithAnalyzers", "projects\PackagesWithAnalyzers\PackagesWithAnalyzers.csproj", "{5D9A3040-DBCD-4401-8B2F-369586DEF29F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackagesWithoutAnalyzers", "projects\PackagesWithoutAnalyzers\PackagesWithoutAnalyzers.csproj", "{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmptyNodes", "projects\EmptyNodes\EmptyNodes.csproj", "{A073D9E7-F9C7-4531-A972-6766CC170B9A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -129,6 +132,10 @@ Global
 		{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A073D9E7-F9C7-4531-A972-6766CC170B9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A073D9E7-F9C7-4531-A972-6766CC170B9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A073D9E7-F9C7-4531-A972-6766CC170B9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A073D9E7-F9C7-4531-A972-6766CC170B9A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -149,6 +156,7 @@ Global
 		{FD32A616-69E1-4313-8CD9-36B6089AC84A} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{5D9A3040-DBCD-4401-8B2F-369586DEF29F} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{A073D9E7-F9C7-4531-A972-6766CC170B9A} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/EmptyNodes/EmptyNodes.csproj
+++ b/projects/EmptyNodes/EmptyNodes.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+
+  <PropertyGroup Label="Empty" />
+
+  <PropertyGroup />
+
+  <PropertyGroup></PropertyGroup>
+
+  <PropertyGroup>
+
+
+  </PropertyGroup>
+
+  <ItemGroup />
+
+  <ItemGroup>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="6.4.1" />
+  </ItemGroup>
+
+  <ImportGroup />
+
+</Project>

--- a/projects/EmptyNodes/Palceholder.cs
+++ b/projects/EmptyNodes/Palceholder.cs
@@ -1,0 +1,4 @@
+﻿namespace EmptyNodes;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/rules/Proj0007.md
+++ b/rules/Proj0007.md
@@ -1,0 +1,29 @@
+# Proj0007: Remove empty nodes
+Empty nodes only add noise, as they contain no information.
+
+## Non-complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup />
+
+  <ItemGroup>
+  </ItemGroup>
+
+</Project>
+```
+
+## Complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="DotNetProjectFile.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />	
+  </ItemGroup>
+
+</Project>
+```

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Remove_empty_nodes.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Remove_empty_nodes.cs
@@ -1,0 +1,30 @@
+﻿namespace Specs.Rules.Remove_empty_nodes;
+
+internal class Remove_empty_nodes
+{
+    public class Reports
+    {
+        [Test]
+        public void empy_nodes()
+            => new RemoveEmptyNodes()
+            .ForProject("EmptyNodes.cs")
+            .HasIssues(
+                new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(08, 3, 08, 33),
+                new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(10, 3, 10, 19),
+                new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(12, 3, 12, 33),
+                new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(14, 3, 17, 18),
+                new Issue("Proj0007", "Remove empty ItemGroup node.").WithSpan(19, 3, 19, 15),
+                new Issue("Proj0007", "Remove empty ItemGroup node.").WithSpan(21, 3, 22, 14),
+                new Issue("Proj0007", "Remove empty ImportGroup node.").WithSpan(28,3, 28,17));
+    }
+
+    public class Guards
+    {
+        [TestCase("CompliantCSharp.cs")]
+        [TestCase("CompliantVB.vb")]
+        public void Projects_with_analyzers(string project)
+             => new RemoveEmptyNodes()
+            .ForProject(project)
+            .HasNoIssues();
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/RemoveEmptyNodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/RemoveEmptyNodes.cs
@@ -1,0 +1,39 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class RemoveEmptyNodes : ProjectFileAnalyzer
+{
+    public RemoveEmptyNodes() : base(Rule.RemoveEmptyNodes) { }
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        foreach (var node in context.Project
+            .AncestorsAndSelf()
+            .SelectMany(p => p.AllChildren()))
+        {
+            Report(node, context, 1);
+        }
+    }
+
+    private void Report(Node node, ProjectFileAnalysisContext context, int level)
+    {
+        var noChildren = true;
+
+        foreach (var child in node.AllChildren())
+        {
+            noChildren = false;
+            Report(child, context, level + 1);
+        }
+
+        if (noChildren && IsEmpty(node.Element, level))
+        {
+            context.ReportDiagnostic(Descriptor, node.Location, node.LocalName);
+        }
+    }
+
+    private static bool IsEmpty(XElement element, int level)
+        => level == 1
+        || (element.Attributes().None() && string.IsNullOrWhiteSpace(element.Value));
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -22,8 +22,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
 ToBeRealeased
-- Proj0006: Add additional files to improve static code analysis (NEW RULE)
-- Proj1000: Use the .NET project file analyzers (NEW RULE)
+- Proj0006: Add additional files to improve static code analysis. (NEW RULE)
+- Proj0007: Remove empty nodes. (NEW RULE)
+- Proj1000: Use the .NET project file analyzers. (NEW RULE)
 v1.0.1
 - Proj0002: Added Microsoft.CodeAnalysis.Analyzers as analyzer to add.
 - Proj0005: Define package reference assets as attributes. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -8,5 +8,6 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0004** Run NuGet security audits automatically](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0004.md)
 * [**Proj0005** Define package reference assets as attributes](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0005.md)
 * [**Proj0006** Add additional files to improve static code analysis](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0006.md)
+* [**Proj0007** Remove empty nodes](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0007.md)
 * [**Proj1000** Use the .NET project file analyzers](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1001.md)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -72,6 +72,16 @@ public static class Rule
         severity: DiagnosticSeverity.Warning,
         isEnabled: true);
 
+    public static DiagnosticDescriptor RemoveEmptyNodes => New(
+        id: 0007,
+        title: "Remove empty nodes",
+        message: "Remove empty {0} node.",
+        description: "Empty nodes only add noise, as they contain no information.",
+        tags: new[] { "noise" },
+        category: Category.Clarity,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
     public static DiagnosticDescriptor UseDotNetProjectFileAnalyzers => New(
         id: 1000,
         title: "Use the .NET project file analyzers",

--- a/src/DotNetProjectFile.Analyzers/Xml/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Node.cs
@@ -1,9 +1,8 @@
-﻿using System.IO;
+﻿using DotNetProjectFile.Xml.Conversion;
+using Microsoft.CodeAnalysis.Text;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Linq;
-using DotNetProjectFile.Xml.Conversion;
-using Microsoft.CodeAnalysis.Text;
 
 namespace DotNetProjectFile.Xml;
 
@@ -54,6 +53,14 @@ public class Node
     /// <summary>Gets the a <see cref="Nodes{T}"/> of children.</summary>
     public Nodes<T> GetChildren<T>() where T : Node => new(this);
 
+    /// <summary>Get all children.</summary>
+    /// <remarks>
+    /// This function exists as source for the <see cref="Nodes{T}"/>.
+    /// With this construction, we can expose all children as collection.
+    /// </remarks>
+    public IEnumerable<Node> AllChildren()
+        => Element.Elements().Select(Create).OfType<Node>();
+
     /// <summary>Gets the <see cref="string"/> value of a child element.</summary>
     public string? GetAttribute([CallerMemberName] string? propertyName = null)
         => Element.Attribute(propertyName)?.Value;
@@ -65,14 +72,6 @@ public class Node
     /// <summary>Gets the value of a child element.</summary>
     public T? GetNode<T>([CallerMemberName] string? propertyName = null)
         => Convert<T>(GetNode(propertyName), propertyName);
-
-    /// <summary>Get all children.</summary>
-    /// <remarks>
-    /// This function exists as source for the <see cref="Nodes{T}"/>.
-    /// With this construction, we can expose all children as collection.
-    /// </remarks>
-    internal IEnumerable<Node> GetAllChildren()
-        => Element.Elements().Select(Create).OfType<Node>();
 
     internal Node? Create(XElement element)
     => element.Name.LocalName switch

--- a/src/DotNetProjectFile.Analyzers/Xml/Nodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Nodes.cs
@@ -42,5 +42,5 @@ public sealed class Nodes<T> : IEnumerable<T> where T : Node
 
     /// <summary>Helper property to select the needed children.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private IEnumerable<T> Items => Parent.GetAllChildren().Where(child => child is T).Cast<T>();
+    private IEnumerable<T> Items => Parent.AllChildren().Where(child => child is T).Cast<T>();
 }


### PR DESCRIPTION
# Proj0007: Remove empty nodes
Empty nodes only add noise, as they contain no information.

## Non-complaint
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup />

  <ItemGroup>
  </ItemGroup>

</Project>
```

## Complaint
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net7.0</TargetFramework>
  </PropertyGroup>

  <ItemGroup>
    <ProjectReference Include="DotNetProjectFile.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />	
  </ItemGroup>

</Project>
```
