### PR TITLE
New Rule Proj0008: Remove folder nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ To add a props file:
 * [**Proj0005** Define package reference assets as attributes](rules/Proj0005.md)
 * [**Proj0006** Add additional files to improve static code analysis](rules/Proj0006.md)
 * [**Proj0007** Remove empty nodes](rules/Proj0007.md)
+* [**Proj0008** Remove folder nodes](rules/Proj0008.md)
 * [**Proj1000** Use the .NET project file analyzers](rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
 

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -29,6 +29,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj0005.md = rules\Proj0005.md
 		rules\Proj0006.md = rules\Proj0006.md
 		rules\Proj0007.md = rules\Proj0007.md
+		rules\Proj0008.md = rules\Proj0008.md
 		rules\Proj1000.md = rules\Proj1000.md
 		rules\Proj1001.md = rules\Proj1001.md
 	EndProjectSection
@@ -68,7 +69,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackagesWithAnalyzers", "pr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackagesWithoutAnalyzers", "projects\PackagesWithoutAnalyzers\PackagesWithoutAnalyzers.csproj", "{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmptyNodes", "projects\EmptyNodes\EmptyNodes.csproj", "{A073D9E7-F9C7-4531-A972-6766CC170B9A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EmptyNodes", "projects\EmptyNodes\EmptyNodes.csproj", "{A073D9E7-F9C7-4531-A972-6766CC170B9A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FolderNodes", "projects\FolderNodes\FolderNodes.csproj", "{B1495B4E-FA18-446E-B01B-935784FF8915}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -136,6 +139,10 @@ Global
 		{A073D9E7-F9C7-4531-A972-6766CC170B9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A073D9E7-F9C7-4531-A972-6766CC170B9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A073D9E7-F9C7-4531-A972-6766CC170B9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1495B4E-FA18-446E-B01B-935784FF8915}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1495B4E-FA18-446E-B01B-935784FF8915}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1495B4E-FA18-446E-B01B-935784FF8915}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1495B4E-FA18-446E-B01B-935784FF8915}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,6 +164,7 @@ Global
 		{5D9A3040-DBCD-4401-8B2F-369586DEF29F} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{A073D9E7-F9C7-4531-A972-6766CC170B9A} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{B1495B4E-FA18-446E-B01B-935784FF8915} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/FolderNodes/FolderNodes.csproj
+++ b/projects/FolderNodes/FolderNodes.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="SomeFolder\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="OtherFolder/" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="*.csproj" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/projects/FolderNodes/Placeholder.cs
+++ b/projects/FolderNodes/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace FolderNodes;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/rules/Proj0005.md
+++ b/rules/Proj0005.md
@@ -8,8 +8,8 @@ as XML attributes, instead of XML elements.
 ``` XML
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup Label="Analyzer">
-    <ProjectReference Include="DotNetProjectFile.Analyzers">
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="DotNetProjectFile.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
   </ItemGroup>
@@ -21,8 +21,8 @@ as XML attributes, instead of XML elements.
 ``` XML
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup Label="Analyzer">
-    <ProjectReference Include="DotNetProjectFile.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="DotNetProjectFile.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 
 </Project>

--- a/rules/Proj0008.md
+++ b/rules/Proj0008.md
@@ -1,0 +1,22 @@
+# Proj0008: Remove folder nodes
+Folders nodes only add noise. They are leftovers of directories created in the
+IDE; allowing to show the folder while it does not contain a file relevant for
+the .NET project yet. This should only exist temporarily.
+
+## Non-complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <Folder Include="SomeFolder\" />
+  </ItemGroup>
+
+</Project>
+```
+
+## Complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+</Project>
+```

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Remove_empty_nodes.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Remove_empty_nodes.cs
@@ -5,7 +5,7 @@ internal class Remove_empty_nodes
     public class Reports
     {
         [Test]
-        public void empy_nodes()
+        public void empty_nodes()
             => new RemoveEmptyNodes()
             .ForProject("EmptyNodes.cs")
             .HasIssues(

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Remove_empty_nodes.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Remove_empty_nodes.cs
@@ -1,30 +1,27 @@
 ﻿namespace Specs.Rules.Remove_empty_nodes;
 
-internal class Remove_empty_nodes
+public class Reports
 {
-    public class Reports
-    {
-        [Test]
-        public void empty_nodes()
-            => new RemoveEmptyNodes()
-            .ForProject("EmptyNodes.cs")
-            .HasIssues(
-                new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(08, 3, 08, 33),
-                new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(10, 3, 10, 19),
-                new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(12, 3, 12, 33),
-                new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(14, 3, 17, 18),
-                new Issue("Proj0007", "Remove empty ItemGroup node.").WithSpan(19, 3, 19, 15),
-                new Issue("Proj0007", "Remove empty ItemGroup node.").WithSpan(21, 3, 22, 14),
-                new Issue("Proj0007", "Remove empty ImportGroup node.").WithSpan(28,3, 28,17));
-    }
+    [Test]
+    public void empty_nodes()
+        => new RemoveEmptyNodes()
+        .ForProject("EmptyNodes.cs")
+        .HasIssues(
+            new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(08, 3, 08, 33),
+            new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(10, 3, 10, 19),
+            new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(12, 3, 12, 33),
+            new Issue("Proj0007", "Remove empty PropertyGroup node.").WithSpan(14, 3, 17, 18),
+            new Issue("Proj0007", "Remove empty ItemGroup node.").WithSpan(19, 3, 19, 15),
+            new Issue("Proj0007", "Remove empty ItemGroup node.").WithSpan(21, 3, 22, 14),
+            new Issue("Proj0007", "Remove empty ImportGroup node.").WithSpan(28, 3, 28, 17));
+}
 
-    public class Guards
-    {
-        [TestCase("CompliantCSharp.cs")]
-        [TestCase("CompliantVB.vb")]
-        public void Projects_with_analyzers(string project)
-             => new RemoveEmptyNodes()
-            .ForProject(project)
-            .HasNoIssues();
-    }
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    public void Projects_with_analyzers(string project)
+         => new RemoveEmptyNodes()
+        .ForProject(project)
+        .HasNoIssues();
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Remove_folder_nodes.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Remove_folder_nodes.cs
@@ -1,0 +1,22 @@
+﻿namespace Specs.Rules.Remove_folder_nodes;
+
+public class Reports
+{
+    [Test]
+    public void folder_nodes()
+        => new RemoveFolderNodes()
+        .ForProject("FolderNodes.cs")
+        .HasIssues(
+            new Issue("Proj0008", "Remove folder node 'SomeFolder'.").WithSpan(08, 5, 08, 36),
+            new Issue("Proj0008", "Remove folder node 'OtherFolder'.").WithSpan(12, 5, 12, 37));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    public void Projects_with_analyzers(string project)
+         => new RemoveFolderNodes()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/RemoveFolderNodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/RemoveFolderNodes.cs
@@ -1,0 +1,18 @@
+﻿namespace DotNetProjectFile.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class RemoveFolderNodes : ProjectFileAnalyzer
+{
+    public RemoveFolderNodes() : base(Rule.RemoveFolderNodes) { }
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        foreach (var folder in context.Project
+             .AncestorsAndSelf()
+             .SelectMany(p => p.ItemGroups)
+             .SelectMany(p => p.Folders))
+        {
+            context.ReportDiagnostic(Descriptor, folder.Location, folder.Include?.TrimEnd('/', '\\'));
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>DotNetProjectFile</RootNamespace>
     <NuGetAudit>true</NuGetAudit>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Label="Package settings">

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -9,5 +9,6 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0005** Define package reference assets as attributes](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0005.md)
 * [**Proj0006** Add additional files to improve static code analysis](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0006.md)
 * [**Proj0007** Remove empty nodes](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0007.md)
+* [**Proj0008** Remove folder nodes](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0008.md)
 * [**Proj1000** Use the .NET project file analyzers](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1001.md)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -82,6 +82,18 @@ public static class Rule
         severity: DiagnosticSeverity.Warning,
         isEnabled: true);
 
+    public static DiagnosticDescriptor RemoveFolderNodes => New(
+       id: 0008,
+       title: "Remove folder nodes",
+       message: "Remove folder node '{0}'.",
+       description:
+        "Folders nodes only add noise. They are leftovers of directories " +
+        "created in the IDE, without adding an actual file to it.",
+       tags: new[] { "noise" },
+       category: Category.Clarity,
+       severity: DiagnosticSeverity.Warning,
+       isEnabled: true);
+
     public static DiagnosticDescriptor UseDotNetProjectFileAnalyzers => New(
         id: 1000,
         title: "Use the .NET project file analyzers",

--- a/src/DotNetProjectFile.Analyzers/Xml/Folder.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Folder.cs
@@ -1,0 +1,16 @@
+﻿using System.IO;
+using System.Xml.Linq;
+
+namespace DotNetProjectFile.Xml;
+
+public sealed class Folder : Node
+{
+    public Folder(XElement element, Project project) : base(element, project) { }
+
+    public string? Include => GetAttribute();
+
+    public DirectoryInfo? Directory
+        => Include is { }
+        ? new(Path.Combine(Project.Path.FullName, Include))
+        : null;
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/ItemGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/ItemGroup.cs
@@ -8,6 +8,7 @@ namespace DotNetProjectFile.Xml;
 /// - Compile
 /// - Content
 /// - EmbeddedResource
+/// - Folder
 /// - Import
 /// - None
 /// - PackageReference
@@ -24,4 +25,7 @@ public sealed class ItemGroup : Node
 
     /// <summary>Gets the child package references.</summary>
     public Nodes<PackageReference> PackageReferences => GetChildren<PackageReference>();
+
+    /// <summary>Gets the child folders.</summary>
+    public Nodes<Folder> Folders => GetChildren<Folder>();
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Node.cs
@@ -77,6 +77,7 @@ public class Node
     => element.Name.LocalName switch
     {
         null => null,
+        nameof(Folder) /*.................*/ => new Folder(element, Project),
         nameof(ImplicitUsings) /*.........*/ => new ImplicitUsings(element, Project),
         nameof(Import) /*.................*/ => new Import(element, Project),
         nameof(ItemGroup) /*..............*/ => new ItemGroup(element, Project),


### PR DESCRIPTION
# Proj0008: Remove folder nodes
Folders nodes only add noise. They are leftovers of directories created in the
IDE; allowing to show the folder while it does not contain a file relevant for
the .NET project yet. This should only exist temporarily.

## Non-complaint
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <ItemGroup>
    <Folder Include="SomeFolder\" />
  </ItemGroup>

</Project>
```

## Complaint
``` XML
<Project Sdk="Microsoft.NET.Sdk">

</Project>
```
