### PR TITLE
New Rule Proj0009: Use the TragetFramework node for a single target framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To add a props file:
 * [**Proj0006** Add additional files to improve static code analysis](rules/Proj0006.md)
 * [**Proj0007** Remove empty nodes](rules/Proj0007.md)
 * [**Proj0008** Remove folder nodes](rules/Proj0008.md)
+* [**Proj0009** Use the TragetFramework node for a single target framework](rules/Proj0009.md)
 * [**Proj1000** Use the .NET project file analyzers](rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
 

--- a/build.sln
+++ b/build.sln
@@ -27,6 +27,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackageReferenceAssetsAsAtt
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackageReferenceAssetsAsElements", "projects\PackageReferenceAssetsAsElements\PackageReferenceAssetsAsElements.csproj", "{7BB4BE09-DAEE-4A39-B64C-772A76B17D86}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TargetFrameworksMultiple", "projects\TargetFrameworksMultiple\TargetFrameworksMultiple.csproj", "{64C424DD-AB37-46A8-B801-E59DBCA46B77}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TargetFrameworksSingle", "projects\TargetFrameworksSingle\TargetFrameworksSingle.csproj", "{43CF7B5F-FC72-4737-A742-1B7AB4D48073}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -77,6 +81,14 @@ Global
 		{7BB4BE09-DAEE-4A39-B64C-772A76B17D86}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7BB4BE09-DAEE-4A39-B64C-772A76B17D86}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BB4BE09-DAEE-4A39-B64C-772A76B17D86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64C424DD-AB37-46A8-B801-E59DBCA46B77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64C424DD-AB37-46A8-B801-E59DBCA46B77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64C424DD-AB37-46A8-B801-E59DBCA46B77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64C424DD-AB37-46A8-B801-E59DBCA46B77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43CF7B5F-FC72-4737-A742-1B7AB4D48073}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43CF7B5F-FC72-4737-A742-1B7AB4D48073}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43CF7B5F-FC72-4737-A742-1B7AB4D48073}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43CF7B5F-FC72-4737-A742-1B7AB4D48073}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -91,6 +103,8 @@ Global
 		{909DAEE9-592F-4FA5-8777-CCDB563D0B49} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{9520C36F-17D6-469B-BD02-4DBBA5B52C26} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{7BB4BE09-DAEE-4A39-B64C-772A76B17D86} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{64C424DD-AB37-46A8-B801-E59DBCA46B77} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{43CF7B5F-FC72-4737-A742-1B7AB4D48073} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -30,6 +30,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj0006.md = rules\Proj0006.md
 		rules\Proj0007.md = rules\Proj0007.md
 		rules\Proj0008.md = rules\Proj0008.md
+		rules\Proj0009.md = rules\Proj0009.md
 		rules\Proj1000.md = rules\Proj1000.md
 		rules\Proj1001.md = rules\Proj1001.md
 	EndProjectSection
@@ -72,6 +73,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EmptyNodes", "projects\EmptyNodes\EmptyNodes.csproj", "{A073D9E7-F9C7-4531-A972-6766CC170B9A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FolderNodes", "projects\FolderNodes\FolderNodes.csproj", "{B1495B4E-FA18-446E-B01B-935784FF8915}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TargetFrameworksSingle", "projects\TargetFrameworksSingle\TargetFrameworksSingle.csproj", "{FAFC92E1-9F20-4D21-9DD2-B8BB9F373250}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TargetFrameworksMultiple", "projects\TargetFrameworksMultiple\TargetFrameworksMultiple.csproj", "{41FE5E25-4A10-4042-B88E-7F285916B417}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -143,6 +148,14 @@ Global
 		{B1495B4E-FA18-446E-B01B-935784FF8915}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B1495B4E-FA18-446E-B01B-935784FF8915}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1495B4E-FA18-446E-B01B-935784FF8915}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAFC92E1-9F20-4D21-9DD2-B8BB9F373250}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAFC92E1-9F20-4D21-9DD2-B8BB9F373250}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAFC92E1-9F20-4D21-9DD2-B8BB9F373250}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAFC92E1-9F20-4D21-9DD2-B8BB9F373250}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41FE5E25-4A10-4042-B88E-7F285916B417}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41FE5E25-4A10-4042-B88E-7F285916B417}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41FE5E25-4A10-4042-B88E-7F285916B417}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41FE5E25-4A10-4042-B88E-7F285916B417}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -165,6 +178,8 @@ Global
 		{BE7A8A3A-49A3-44AD-A57A-FA91217D6E80} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{A073D9E7-F9C7-4531-A972-6766CC170B9A} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{B1495B4E-FA18-446E-B01B-935784FF8915} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{FAFC92E1-9F20-4D21-9DD2-B8BB9F373250} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{41FE5E25-4A10-4042-B88E-7F285916B417} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/TargetFrameworksMultiple/Placeholder.cs
+++ b/projects/TargetFrameworksMultiple/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace TargetFrameworksMultiple;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/projects/TargetFrameworksMultiple/TargetFrameworksMultiple.csproj
+++ b/projects/TargetFrameworksMultiple/TargetFrameworksMultiple.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/projects/TargetFrameworksSingle/Placeholder.cs
+++ b/projects/TargetFrameworksSingle/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace TargetFrameworksMultiple;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/projects/TargetFrameworksSingle/TargetFrameworksSingle.csproj
+++ b/projects/TargetFrameworksSingle/TargetFrameworksSingle.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/rules/Proj0009.md
+++ b/rules/Proj0009.md
@@ -1,0 +1,25 @@
+# Proj0009: Use the TragetFramework node for a single target framework
+To prevent confusion, only use the TargetFrameworks node when there are
+multiple target frameworks. Otherwise use the TargetFramework node.
+
+## Non-complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>
+```
+
+## Complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>
+```

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_single_target_framework.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Define_single_target_framework.cs
@@ -1,0 +1,22 @@
+﻿namespace Specs.Rules.Define_single_target_framework;
+
+public class Reports
+{
+    [Test]
+    public void defined_in_traget_frameworks()
+        => new DefineSingleTargetFramework()
+        .ForProject("TargetFrameworksSingle.cs")
+        .HasIssues(
+            new Issue("Proj0009", "Use the TargetFramework node instead.").WithSpan(3, 5, 3, 47));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    [TestCase("TargetFrameworksMultiple.cs")]
+    public void Projects_with_analyzers(string project)
+         => new DefineSingleTargetFramework()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/DefineSingleTargetFramework.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/DefineSingleTargetFramework.cs
@@ -1,0 +1,18 @@
+﻿namespace DotNetProjectFile.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class DefineSingleTargetFramework : ProjectFileAnalyzer
+{
+    public DefineSingleTargetFramework() : base(Rule.DefineSingleTargetFramework) { }
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        foreach (var frameworks in context.Project.AncestorsAndSelf()
+            .SelectMany(p => p.PropertyGroups)
+            .SelectMany(p => p.TargetFrameworks)
+            .Where(f => f.Values.Count <= 1))
+        {
+            context.ReportDiagnostic(Descriptor, frameworks.Location);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/RemoveEmptyNodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/RemoveEmptyNodes.cs
@@ -11,7 +11,7 @@ public sealed class RemoveEmptyNodes : ProjectFileAnalyzer
     {
         foreach (var node in context.Project
             .AncestorsAndSelf()
-            .SelectMany(p => p.AllChildren()))
+            .SelectMany(p => p.Children()))
         {
             Report(node, context, 1);
         }
@@ -21,7 +21,7 @@ public sealed class RemoveEmptyNodes : ProjectFileAnalyzer
     {
         var noChildren = true;
 
-        foreach (var child in node.AllChildren())
+        foreach (var child in node.Children())
         {
             noChildren = false;
             Report(child, context, level + 1);

--- a/src/DotNetProjectFile.Analyzers/Analyzers/RunNuGetSecurityAuditsAutomatically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/RunNuGetSecurityAuditsAutomatically.cs
@@ -9,7 +9,7 @@ public sealed class RunNuGetSecurityAuditsAutomatically : ProjectFileAnalyzer
     {
         var audits = context.Project.AncestorsAndSelf()
           .SelectMany(p => p.PropertyGroups)
-          .SelectMany(g => g.NuGetAudits);
+          .SelectMany(g => g.NuGetAudit);
 
         if (audits.None() || audits.Any(a => a.Value != true))
         {

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -19,12 +19,14 @@
     <Authors>Corniel Nobel</Authors>
     <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
     <PackageTags>Code Analysis;Project files;csproj;vbproj</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
-ToBeRealeased
+v1.0.2
 - Proj0006: Add additional files to improve static code analysis. (NEW RULE)
 - Proj0007: Remove empty nodes. (NEW RULE)
+- Proj0008: Remove folder nodes. (NEW RULE)
+- Proj0009: Use the TragetFramework node for a single target framework. (NEW RULE)
 - Proj1000: Use the .NET project file analyzers. (NEW RULE)
 v1.0.1
 - Proj0002: Added Microsoft.CodeAnalysis.Analyzers as analyzer to add.

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -10,5 +10,6 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0006** Add additional files to improve static code analysis](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0006.md)
 * [**Proj0007** Remove empty nodes](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0007.md)
 * [**Proj0008** Remove folder nodes](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0008.md)
+* [**Proj0009** Use the TragetFramework node for a single target framework](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0009.md)
 * [**Proj1000** Use the .NET project file analyzers](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1001.md)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -1,5 +1,7 @@
 ﻿#pragma warning disable SA1118 // Parameter should not span multiple lines: readability for descriptions.
 
+using DotNetProjectFile.Xml;
+
 namespace DotNetProjectFile;
 
 public static class Rule
@@ -83,16 +85,28 @@ public static class Rule
         isEnabled: true);
 
     public static DiagnosticDescriptor RemoveFolderNodes => New(
-       id: 0008,
-       title: "Remove folder nodes",
-       message: "Remove folder node '{0}'.",
-       description:
-        "Folders nodes only add noise. They are leftovers of directories " +
-        "created in the IDE, without adding an actual file to it.",
-       tags: new[] { "noise" },
-       category: Category.Clarity,
-       severity: DiagnosticSeverity.Warning,
-       isEnabled: true);
+        id: 0008,
+        title: "Remove folder nodes",
+        message: "Remove folder node '{0}'.",
+        description:
+            "Folders nodes only add noise. They are leftovers of directories " +
+            "created in the IDE, without adding an actual file to it.",
+        tags: new[] { "noise" },
+        category: Category.Clarity,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
+    public static DiagnosticDescriptor DefineSingleTargetFramework => New(
+        id: 0009,
+        title: "Use the TragetFramework node for a single target framework",
+        message: "Use the TargetFramework node instead.",
+        description:
+            "To prevent confusion, only use the TargetFrameworks node when " +
+            "there are multiple target frameworks.",
+        tags: new[] { "target framework", "confusion" },
+        category: Category.Clarity,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
 
     public static DiagnosticDescriptor UseDotNetProjectFileAnalyzers => New(
         id: 1000,

--- a/src/DotNetProjectFile.Analyzers/Xml/Folder.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Folder.cs
@@ -7,7 +7,7 @@ public sealed class Folder : Node
 {
     public Folder(XElement element, Project project) : base(element, project) { }
 
-    public string? Include => GetAttribute();
+    public string? Include => Attribute();
 
     public DirectoryInfo? Directory
         => Include is { }

--- a/src/DotNetProjectFile.Analyzers/Xml/Import.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Import.cs
@@ -28,7 +28,7 @@ public sealed class Import : Node
 
     private Project? GetValue()
     {
-        var location = new FileInfo(Path.Combine(Project.Path.Directory.FullName, GetAttribute("Project")));
+        var location = new FileInfo(Path.Combine(Project.Path.Directory.FullName, Attribute("Project")));
         return Project.Projects.TryResolve(location);
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/ItemGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/ItemGroup.cs
@@ -24,8 +24,8 @@ public sealed class ItemGroup : Node
     public ItemGroup(XElement element, Project project) : base(element, project) { }
 
     /// <summary>Gets the child package references.</summary>
-    public Nodes<PackageReference> PackageReferences => GetChildren<PackageReference>();
+    public Nodes<PackageReference> PackageReferences => Children<PackageReference>();
 
     /// <summary>Gets the child folders.</summary>
-    public Nodes<Folder> Folders => GetChildren<Folder>();
+    public Nodes<Folder> Folders => Children<Folder>();
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Node.cs
@@ -24,7 +24,7 @@ public class Node
     public virtual string LocalName => GetType().Name;
 
     /// <summary>Gets the label of the node.</summary>
-    public string? Label => GetAttribute();
+    public string? Label => Attribute();
 
     /// <summary>Get the line info.</summary>
     public IXmlLineInfo LineInfo => Element;
@@ -51,27 +51,19 @@ public class Node
     public override string ToString() => Element.ToString();
 
     /// <summary>Gets the a <see cref="Nodes{T}"/> of children.</summary>
-    public Nodes<T> GetChildren<T>() where T : Node => new(this);
+    public Nodes<T> Children<T>() where T : Node => new(this);
 
     /// <summary>Get all children.</summary>
     /// <remarks>
     /// This function exists as source for the <see cref="Nodes{T}"/>.
     /// With this construction, we can expose all children as collection.
     /// </remarks>
-    public IEnumerable<Node> AllChildren()
+    public IEnumerable<Node> Children()
         => Element.Elements().Select(Create).OfType<Node>();
 
     /// <summary>Gets the <see cref="string"/> value of a child element.</summary>
-    public string? GetAttribute([CallerMemberName] string? propertyName = null)
+    public string? Attribute([CallerMemberName] string? propertyName = null)
         => Element.Attribute(propertyName)?.Value;
-
-    /// <summary>Gets the <see cref="string"/> value of a child element.</summary>
-    public string? GetNode([CallerMemberName] string? propertyName = null)
-        => Element.Element(propertyName)?.Value;
-
-    /// <summary>Gets the value of a child element.</summary>
-    public T? GetNode<T>([CallerMemberName] string? propertyName = null)
-        => Convert<T>(GetNode(propertyName), propertyName);
 
     internal Node? Create(XElement element)
     => element.Name.LocalName switch
@@ -84,6 +76,8 @@ public class Node
         nameof(NuGetAudit) /*.............*/ => new NuGetAudit(element, Project),
         nameof(PackageReference) /*.......*/ => new PackageReference(element, Project),
         nameof(PropertyGroup) /*..........*/ => new PropertyGroup(element, Project),
+        nameof(TargetFramework) /*........*/ => new TargetFramework(element, Project),
+        nameof(TargetFrameworks) /*.......*/ => new TargetFrameworks(element, Project),
         _ => new Unknown(element, Project),
     };
 

--- a/src/DotNetProjectFile.Analyzers/Xml/Nodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Nodes.cs
@@ -42,5 +42,5 @@ public sealed class Nodes<T> : IEnumerable<T> where T : Node
 
     /// <summary>Helper property to select the needed children.</summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private IEnumerable<T> Items => Parent.AllChildren().Where(child => child is T).Cast<T>();
+    private IEnumerable<T> Items => Parent.Children().Where(child => child is T).Cast<T>();
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/PackageReference.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/PackageReference.cs
@@ -6,7 +6,7 @@ public sealed class PackageReference : Node
 {
     public PackageReference(XElement element, Project project) : base(element, project) { }
 
-    public string? Include => GetAttribute();
+    public string? Include => Attribute();
 
-    public string? Version => GetAttribute();
+    public string? Version => Attribute();
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/Project.cs
@@ -23,11 +23,11 @@ public sealed class Project : Node
 
     internal readonly Projects Projects;
 
-    public Nodes<Import> Imports => GetChildren<Import>();
+    public Nodes<Import> Imports => Children<Import>();
 
-    public Nodes<PropertyGroup> PropertyGroups => GetChildren<PropertyGroup>();
+    public Nodes<PropertyGroup> PropertyGroups => Children<PropertyGroup>();
 
-    public Nodes<ItemGroup> ItemGroups => GetChildren<ItemGroup>();
+    public Nodes<ItemGroup> ItemGroups => Children<ItemGroup>();
 
     public IEnumerable<Project> AncestorsAndSelf()
     {

--- a/src/DotNetProjectFile.Analyzers/Xml/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/PropertyGroup.cs
@@ -7,9 +7,11 @@ public sealed class PropertyGroup : Node
     /// <summary>Initializes a new instance of the <see cref="PropertyGroup"/> class.</summary>
     public PropertyGroup(XElement element, Project project) : base(element, project) { }
 
-    public Nodes<ImplicitUsings> ImplicitUsings => GetChildren<ImplicitUsings>();
+    public Nodes<TargetFramework> TargetFramework => Children<TargetFramework>();
 
-    public Nodes<NuGetAudit> NuGetAudits => GetChildren<NuGetAudit>();
+    public Nodes<TargetFrameworks> TargetFrameworks => Children<TargetFrameworks>();
 
-    public string? RootNamespace => GetNode();
+    public Nodes<ImplicitUsings> ImplicitUsings => Children<ImplicitUsings>();
+
+    public Nodes<NuGetAudit> NuGetAudit => Children<NuGetAudit>();
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/TargetFramework.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/TargetFramework.cs
@@ -1,0 +1,10 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Xml;
+
+public sealed class TargetFramework : Node
+{
+    public TargetFramework(XElement element, Project? project) : base(element, project) { }
+
+    public string? Values => Element.Value;
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/TargetFrameworks.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/TargetFrameworks.cs
@@ -1,0 +1,12 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Xml;
+
+public sealed class TargetFrameworks : Node
+{
+    public TargetFrameworks(XElement element, Project? project) : base(element, project) { }
+
+    public IReadOnlyList<string> Values
+        => Element.Value?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+        ?? Array.Empty<string>();
+}


### PR DESCRIPTION
# Proj0009: Use the TragetFramework node for a single target framework
To prevent confusion, only use the TargetFrameworks node when there are
multiple target frameworks. Otherwise use the TargetFramework node.

## Non-complaint
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFrameworks>net7.0</TargetFrameworks>
  </PropertyGroup>

</Project>
```

## Complaint
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net7.0</TargetFramework>
  </PropertyGroup>

</Project>
```
