### PR TITLE
Trigger ProjectFileAnalysisContext for projects and linked props

### DIFF
--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AddAdditionalFile.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AddAdditionalFile.cs
@@ -7,9 +7,9 @@ public sealed class AddAdditionalFile : MsBuildProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var project in context.Project.AncestorsAndSelf().Where(p => !p.IsAdditional))
+        if (!context.Project.IsAdditional)
         {
-            context.ReportDiagnostic(Descriptor, project.Location, project.Path.Name);
+            context.ReportDiagnostic(Descriptor, context.Project, context.Project.Path.Name);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageReferenceAssetsAsAttributes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageReferenceAssetsAsAttributes.cs
@@ -7,12 +7,11 @@ public sealed class DefinePackageReferenceAssetsAsAttributes : MsBuildProjectFil
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var reference in context.Project.AncestorsAndSelf()
-            .SelectMany(p => p.ItemGroups)
+        foreach (var reference in context.Project.ItemGroups
             .SelectMany(g => g.PackageReferences)
             .Where(HasAssetsElement))
         {
-            context.ReportDiagnostic(Descriptor, reference.Location, reference.Include);
+            context.ReportDiagnostic(Descriptor, reference, reference.Include);
         }
     }
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineSingleTargetFramework.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineSingleTargetFramework.cs
@@ -7,12 +7,11 @@ public sealed class DefineSingleTargetFramework : MsBuildProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var frameworks in context.Project.AncestorsAndSelf()
-            .SelectMany(p => p.PropertyGroups)
+        foreach (var frameworks in context.Project.PropertyGroups
             .SelectMany(p => p.TargetFrameworks)
             .Where(f => f.Values.Count <= 1))
         {
-            context.ReportDiagnostic(Descriptor, frameworks.Location);
+            context.ReportDiagnostic(Descriptor, frameworks);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineUsingsExplicit.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineUsingsExplicit.cs
@@ -7,12 +7,11 @@ public sealed class DefineUsingsExplicit : MsBuildProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var @implicit in context.Project.AncestorsAndSelf()
-            .SelectMany(p => p.PropertyGroups)
+        foreach (var @implicit in context.Project.PropertyGroups
             .SelectMany(g => g.ImplicitUsings)
             .Where(i => IsEnabled(i.Value)))
         {
-            context.ReportDiagnostic(Descriptor, @implicit.Location);
+            context.ReportDiagnostic(Descriptor, @implicit);
         }
     }
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveEmptyNodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveEmptyNodes.cs
@@ -34,5 +34,5 @@ public sealed class RemoveEmptyNodes : MsBuildProjectFileAnalyzer
     private static bool IsEmpty(XElement element, int level)
         => element.Name.LocalName != nameof(Import)
         && (level == 1
-            || element.Attributes().None() && string.IsNullOrWhiteSpace(element.Value));
+        || (element.Attributes().None() && string.IsNullOrWhiteSpace(element.Value)));
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveEmptyNodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveEmptyNodes.cs
@@ -9,9 +9,7 @@ public sealed class RemoveEmptyNodes : MsBuildProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var node in context.Project
-            .AncestorsAndSelf()
-            .SelectMany(p => p.Children()))
+        foreach (var node in context.Project.Children())
         {
             Report(node, context, 1);
         }
@@ -29,7 +27,7 @@ public sealed class RemoveEmptyNodes : MsBuildProjectFileAnalyzer
 
         if (noChildren && IsEmpty(node.Element, level))
         {
-            context.ReportDiagnostic(Descriptor, node.Location, node.LocalName);
+            context.ReportDiagnostic(Descriptor, node, node.LocalName);
         }
     }
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveFolderNodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveFolderNodes.cs
@@ -7,12 +7,9 @@ public sealed class RemoveFolderNodes : MsBuildProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var folder in context.Project
-             .AncestorsAndSelf()
-             .SelectMany(p => p.ItemGroups)
-             .SelectMany(p => p.Folders))
+        foreach (var folder in context.Project.ItemGroups.SelectMany(p => p.Folders))
         {
-            context.ReportDiagnostic(Descriptor, folder.Location, folder.Include?.TrimEnd('/', '\\'));
+            context.ReportDiagnostic(Descriptor, folder, folder.Include?.TrimEnd('/', '\\'));
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunNuGetSecurityAuditsAutomatically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunNuGetSecurityAuditsAutomatically.cs
@@ -13,7 +13,7 @@ public sealed class RunNuGetSecurityAuditsAutomatically : MsBuildProjectFileAnal
 
         if (audits.None() || audits.Any(a => a.Value != true))
         {
-            context.ReportDiagnostic(Descriptor, context.Project.Location);
+            context.ReportDiagnostic(Descriptor, context.Project);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunNuGetSecurityAuditsAutomatically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunNuGetSecurityAuditsAutomatically.cs
@@ -7,13 +7,16 @@ public sealed class RunNuGetSecurityAuditsAutomatically : MsBuildProjectFileAnal
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        var audits = context.Project.AncestorsAndSelf()
-          .SelectMany(p => p.PropertyGroups)
-          .SelectMany(g => g.NuGetAudit);
-
-        if (audits.None() || audits.Any(a => a.Value != true))
+        if (context.Project.IsProject)
         {
-            context.ReportDiagnostic(Descriptor, context.Project);
+            var audits = context.Project.AncestorsAndSelf()
+              .SelectMany(p => p.PropertyGroups)
+              .SelectMany(g => g.NuGetAudit);
+
+            if (audits.None() || audits.Any(a => a.Value != true))
+            {
+                context.ReportDiagnostic(Descriptor, context.Project);
+            }
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzers.cs
@@ -14,7 +14,7 @@ public sealed class UseAnalyzers : MsBuildProjectFileAnalyzer
 
         if (packageReferences.None(r => r.Include.Contains("DotNetProjectFile.Analyzers", StringComparison.OrdinalIgnoreCase)))
         {
-            context.ReportDiagnostic(Descriptor, context.Project.Location);
+            context.ReportDiagnostic(Descriptor, context.Project);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzers.cs
@@ -7,14 +7,17 @@ public sealed class UseAnalyzers : MsBuildProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        var packageReferences = context.Project.AncestorsAndSelf()
+        if (context.Project.IsProject)
+        {
+            var packageReferences = context.Project.AncestorsAndSelf()
             .SelectMany(p => p.ItemGroups)
             .SelectMany(group => group.PackageReferences)
             .ToArray();
 
-        if (packageReferences.None(r => r.Include.Contains("DotNetProjectFile.Analyzers", StringComparison.OrdinalIgnoreCase)))
-        {
-            context.ReportDiagnostic(Descriptor, context.Project);
+            if (packageReferences.None(r => r.Include.Contains("DotNetProjectFile.Analyzers", StringComparison.OrdinalIgnoreCase)))
+            {
+                context.ReportDiagnostic(Descriptor, context.Project);
+            }
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzersForPackages.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzersForPackages.cs
@@ -17,7 +17,7 @@ public sealed class UseAnalyzersForPackages : MsBuildProjectFileAnalyzer
             if (packageReferences.None(analyzer.IsMatch)
                 && context.Compilation.ReferencedAssemblyNames.FirstOrDefault(analyzer.IsMatch) is { } reference)
             {
-                context.ReportDiagnostic(Descriptor, Location.None, analyzer.Package, reference.Name);
+                context.ReportDiagnostic(Descriptor, context.Project, analyzer.Package, reference.Name);
             }
         }
     }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzersForPackages.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzersForPackages.cs
@@ -7,17 +7,20 @@ public sealed class UseAnalyzersForPackages : MsBuildProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        var packageReferences = context.Project.AncestorsAndSelf()
+        if (context.Project.IsProject)
+        {
+            var packageReferences = context.Project.AncestorsAndSelf()
             .SelectMany(p => p.ItemGroups)
             .SelectMany(group => group.PackageReferences)
             .ToArray();
 
-        foreach (var analyzer in Analyzers)
-        {
-            if (packageReferences.None(analyzer.IsMatch)
-                && context.Compilation.ReferencedAssemblyNames.FirstOrDefault(analyzer.IsMatch) is { } reference)
+            foreach (var analyzer in Analyzers)
             {
-                context.ReportDiagnostic(Descriptor, context.Project, analyzer.Package, reference.Name);
+                if (packageReferences.None(analyzer.IsMatch)
+                    && context.Compilation.ReferencedAssemblyNames.FirstOrDefault(analyzer.IsMatch) is { } reference)
+                {
+                    context.ReportDiagnostic(Descriptor, context.Project, analyzer.Package, reference.Name);
+                }
             }
         }
     }

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -29,6 +29,6 @@ public readonly struct ProjectFileAnalysisContext
     }
 
     /// <summary>Reports a diagnostic about the project file.</summary>
-    public void ReportDiagnostic(DiagnosticDescriptor descriptor, Location location, params object?[]? messageArgs)
-        => Report(Diagnostic.Create(descriptor, location, messageArgs));
+    public void ReportDiagnostic(DiagnosticDescriptor descriptor, Node node, params object?[]? messageArgs)
+        => Report(Diagnostic.Create(descriptor, node.Location, messageArgs));
 }

--- a/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
@@ -11,7 +11,10 @@ internal static class AnalysisContextExtensions
             if (projects.EntryPoint(c.Compilation.Assembly) is { } project
                 && string.IsNullOrEmpty(project.Element.Name.NamespaceName))
             {
-                action.Invoke(new(project, c.Compilation, c.Options, c.CancellationToken, c.ReportDiagnostic));
+                foreach (var p in project.AncestorsAndSelf())
+                {
+                    action.Invoke(new(p, c.Compilation, c.Options, c.CancellationToken, c.ReportDiagnostic));
+                }
             }
         });
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Import.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Import.cs
@@ -29,6 +29,6 @@ public sealed class Import : Node
     private Project? GetValue()
     {
         var location = new FileInfo(Path.Combine(Project.Path.Directory.FullName, Attribute("Project")));
-        return Project.Projects.TryResolve(location);
+        return Project.Projects.TryResolve(location, isProject: false);
     }
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -6,16 +6,19 @@ namespace DotNetProjectFile.MsBuild;
 
 public sealed class Project : Node
 {
-    private Project(FileInfo path, SourceText text, Projects projects, bool isAdditional)
+    private Project(FileInfo path, SourceText text, Projects projects, bool isAdditional, bool isProject)
         : base(XElement.Parse(text.ToString(), LoadOptions), null!)
     {
         Path = path;
         Text = text;
         Projects = projects;
         IsAdditional = isAdditional;
+        IsProject = isProject;
     }
 
     public bool IsAdditional { get; }
+
+    public bool IsProject { get; }
 
     public FileInfo Path { get; }
 
@@ -44,14 +47,14 @@ public sealed class Project : Node
         yield return this;
     }
 
-    public static Project Load(FileInfo file, Projects projects)
+    public static Project Load(FileInfo file, Projects projects, bool isProject)
     {
         using var reader = file.OpenText();
-        return new(file, SourceText.From(reader.ReadToEnd()), projects, isAdditional: false);
+        return new(file, SourceText.From(reader.ReadToEnd()), projects, isAdditional: false, isProject);
     }
 
-    public static Project Load(AdditionalText text, Projects projects)
-        => new(new(text.Path), text.GetText()!, projects, isAdditional: true);
+    public static Project Load(AdditionalText text, Projects projects, bool isProject)
+        => new(new(text.Path), text.GetText()!, projects, isAdditional: true, isProject);
 
     private static readonly LoadOptions LoadOptions = LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo;
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Projects.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Projects.cs
@@ -19,7 +19,7 @@ public sealed class Projects
         ? EntryPointFromAdditionTexts(assembly.Name) ?? EntryPointFromAssembly(assembly)
         : null;
 
-    public Project? TryResolve(FileInfo location)
+    public Project? TryResolve(FileInfo location, bool isProject)
     {
         lock (locker)
         {
@@ -30,13 +30,13 @@ public sealed class Projects
             else if (AdditionalTexts.TryGetValue(location, out var additional)
                 && IsProject(location))
             {
-                project = Project.Load(additional, this);
+                project = Project.Load(additional, this, isProject);
                 Resolved[location] = project;
                 return project;
             }
             else if (IsProject(location))
             {
-                project = Project.Load(location, this);
+                project = Project.Load(location, this, isProject);
                 Resolved[location] = project;
                 return project;
             }
@@ -51,7 +51,7 @@ public sealed class Projects
     {
         var projects = AdditionalTexts.Keys.Where(IsProject)
             .Where(l => HasName(l, name))
-            .Select(TryResolve)
+            .Select(f => TryResolve(f, isProject: true))
             .ToArray();
 
         return projects.Length == 1 ? projects[0] : null;
@@ -69,7 +69,7 @@ public sealed class Projects
         var projects = directories.SelectMany(d => d.EnumerateFiles())
             .Where(IsProject)
             .Where(l => HasName(l, assembly.Name))
-            .Select(TryResolve)
+            .Select(f => TryResolve(f, isProject: true))
             .ToArray();
 
         return projects.Length == 1 ? projects[0] : null;


### PR DESCRIPTION
For each resolved MS Build project file the ProjectFileAnalysisContext is triggered, instead of requiring rules to call `.AncestorsAndSelf()`.