### PR TITLE
New Rule Proj1003: Add Sonar analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ To add a props file:
 * [**Proj0009** Use the TragetFramework node for a single target framework](rules/Proj0009.md)
 * [**Proj1000** Use the .NET project file analyzers](rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
+* [**Proj1003** Use Sonar analyzers](rules/Proj1003.md)
 
 ## Reference an analyzer from a project
 For debugging/development purposes, it can be useful to reference the analyzer

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -33,6 +33,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj0009.md = rules\Proj0009.md
 		rules\Proj1000.md = rules\Proj1000.md
 		rules\Proj1001.md = rules\Proj1001.md
+		rules\Proj1003.md = rules\Proj1003.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{00669DF6-1449-41AA-8AD3-FA84194CE5B4}"
@@ -84,6 +85,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "design", "design", "{D2F3FB
 		design\logo.psd = design\logo.psd
 		design\logo_128x128.png = design\logo_128x128.png
 	EndProjectSection
+EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "EmptyProjectVB", "projects\EmptyProjectVB\EmptyProjectVB.vbproj", "{F8AE1953-6DE9-4F88-A78D-B6C173BA5634}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -163,6 +166,10 @@ Global
 		{41FE5E25-4A10-4042-B88E-7F285916B417}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{41FE5E25-4A10-4042-B88E-7F285916B417}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41FE5E25-4A10-4042-B88E-7F285916B417}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8AE1953-6DE9-4F88-A78D-B6C173BA5634}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8AE1953-6DE9-4F88-A78D-B6C173BA5634}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8AE1953-6DE9-4F88-A78D-B6C173BA5634}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8AE1953-6DE9-4F88-A78D-B6C173BA5634}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -188,6 +195,7 @@ Global
 		{FAFC92E1-9F20-4D21-9DD2-B8BB9F373250} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{41FE5E25-4A10-4042-B88E-7F285916B417} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{D2F3FB65-3FCE-4424-B2F6-7BF054A424D2} = {BED71055-3C56-4C5B-9D83-A7B2CCD3B8CA}
+		{F8AE1953-6DE9-4F88-A78D-B6C173BA5634} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/CompliantCSharp/CompliantCSharp.csproj
+++ b/projects/CompliantCSharp/CompliantCSharp.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup Label="Analyzers">
     <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 
   <ItemGroup>

--- a/projects/CompliantVB/CompliantVB.vbproj
+++ b/projects/CompliantVB/CompliantVB.vbproj
@@ -9,6 +9,7 @@
 
   <ItemGroup Label="Analyzers">
     <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="SonarAnalyzer.VisualBasic" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
   
   <ItemGroup>

--- a/projects/EmptyProjectVB/EmptyProjectVB.vbproj
+++ b/projects/EmptyProjectVB/EmptyProjectVB.vbproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>EmptyProjectVB</RootNamespace>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/projects/EmptyProjectVB/Placeholder.vb
+++ b/projects/EmptyProjectVB/Placeholder.vb
@@ -1,0 +1,3 @@
+<Serializable>
+Public NotInheritable Class Placeholder
+End Class

--- a/rules/Proj1003.md
+++ b/rules/Proj1003.md
@@ -1,0 +1,32 @@
+# Proj1003: Use Sonar analyzers
+[SonarSource](https://www.sonarsource.com/) has implemented multiple generic
+Roslyn static code analysis rules both for C# and Visual Basic. These Roslyn
+analyzers allow you to produce safe, reliable and maintainable code by helping
+you find and correct bugs, vulnerabilities and code smells in your codebase.
+It is strongly advised to enable this rules on all your projects.
+
+See: https://github.com/SonarSource/sonar-dotnet
+
+## Complaint
+For C# projects:
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup Label="Analyzers">
+    <ProjectReference Include="SonarAnalyzer.CSharp" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+  </ItemGroup>
+
+</Project>
+```
+
+For VB.NET projects:
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup Label="Analyzers">
+    <ProjectReference Include="SonarAnalyzer.VisualBasic" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+  </ItemGroup>
+
+</Project>
+```
+

--- a/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/Issue.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/FluentAssertions/Issue.cs
@@ -5,9 +5,11 @@ namespace FluentAssertions;
 internal sealed record Issue(
     string Id,
     string Message, 
-    LinePositionSpan Span = default,
+    LinePositionSpan Span,
     DiagnosticSeverity Severity = DiagnosticSeverity.Warning)
 {
+    public Issue(string id, string message) : this(id, message, new(new(0, 1), new(0, 2))) { }
+
     public Issue WithSpan(int lineStart, int posStart, int lineEnd, int posEnd)
         => this with
         {

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/All.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/All.cs
@@ -21,7 +21,7 @@ public class Guards
         }
 
         // Do not reference project to itself.
-        context.HasIssue(new Issue("Proj1000", "Use the .NET project file analyzers.").WithSpan(0, 1, 0, 2));
+        context.HasIssue(new Issue("Proj1000", "Use the .NET project file analyzers."));
     }
 
     private static IEnumerable<DiagnosticAnalyzer> Analyzers

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Add_additional_files.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Add_additional_files.cs
@@ -7,7 +7,7 @@ public class Reports
         => new AddAdditionalFile()
         .ForProject("EmptyProject.cs")
         .HasIssue(
-            new Issue("Proj0006", "Add 'EmptyProject.csproj' to the additional files.").WithSpan(0, 1, 0, 2));
+            new Issue("Proj0006", "Add 'EmptyProject.csproj' to the additional files."));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Run_NuGet_security_audits_automatically.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Run_NuGet_security_audits_automatically.cs
@@ -7,14 +7,14 @@ public class Reports
        => new RunNuGetSecurityAuditsAutomatically()
        .ForProject("DisabledNugetAudit.cs")
        .HasIssue(
-           new Issue("Proj0004", "Run NuGet security audits automatically.").WithSpan(0, 1, 0, 2));
+           new Issue("Proj0004", "Run NuGet security audits automatically."));
 
     [Test]
     public void on_not_configured_NuGet_audit()
         => new RunNuGetSecurityAuditsAutomatically()
         .ForProject("NoNugetAudit.cs")
         .HasIssue(
-            new Issue("Proj0004", "Run NuGet security audits automatically.").WithSpan(0, 1, 0, 2));
+            new Issue("Proj0004", "Run NuGet security audits automatically."));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_Sonar_analyzers.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_Sonar_analyzers.cs
@@ -1,0 +1,28 @@
+﻿namespace Rules.MS_Build.Use_Sonar_analyzers;
+
+public class Reports
+{
+    [Test]
+    public void missing_analyzer_for_CSharp()
+        => new UseSonarAnalyzers()
+        .ForProject("EmptyProject.cs")
+        .HasIssue(
+            new Issue("Proj1003", "Add SonarAnalyzer.CSharp."));
+
+    [Test]
+    public void missing_analyzer_for_Visual_Basic()
+        => new UseSonarAnalyzers()
+        .ForProject("EmptyProjectVB.vb")
+        .HasIssue(
+            new Issue("Proj1003", "Add SonarAnalyzer.VisualBasic."));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    public void Projects_with_analyzers(string project)
+         => new UseSonarAnalyzers()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_dotnet_project_file_analyzers.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_dotnet_project_file_analyzers.cs
@@ -7,7 +7,7 @@ public class Reports
         => new UseAnalyzers()
         .ForProject("EmptyProject.cs")
         .HasIssue(
-            new Issue("Proj1000", "Use the .NET project file analyzers.").WithSpan(0, 1, 0, 2));
+            new Issue("Proj1000", "Use the .NET project file analyzers."));
 }
 
 public class Guards

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseSonarAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseSonarAnalyzers.cs
@@ -1,0 +1,27 @@
+﻿namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class UseSonarAnalyzers : MsBuildProjectFileAnalyzer
+{
+    public UseSonarAnalyzers() : base(Rule.UseSonarAnalyzers) { }
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (context.Project.IsProject
+            && Include(context.Compilation.Options.Language) is { } include
+            && context.Project.ItemGroups.SelectMany(i => i.PackageReferences).None(p => Includes(p, include)))
+        {
+            context.ReportDiagnostic(Descriptor, context.Project, include);
+        }
+    }
+
+    private bool Includes(PackageReference reference, string include)
+        => string.Equals(reference.Include, include, StringComparison.OrdinalIgnoreCase);
+
+    private static string? Include(string language) => language switch
+    {
+        LanguageNames.CSharp => "SonarAnalyzer.CSharp",
+        LanguageNames.VisualBasic => "SonarAnalyzer.VisualBasic",
+        _ => null,
+    };
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -22,6 +22,8 @@
     <Version>1.0.3</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+ToBeReleased
+- Proj1003: Use Sonar Analyzers. (NEW RULE)
 v1.0.3
 - Proj0007: &lt;Import &gt; is never an empty node. (FP)
 v1.0.2
@@ -50,7 +52,7 @@ v1.0.0
     <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Roslyn dependencies">
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" />
   </ItemGroup>

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -13,3 +13,4 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0009** Use the TragetFramework node for a single target framework](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj0009.md)
 * [**Proj1000** Use the .NET project file analyzers](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/Proj1001.md)
+* [**Proj1003** Use Sonar analyzers](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/rules/rules/Proj1003.md)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -128,6 +128,15 @@ public static class Rule
         category: Category.CodeQuality,
         isEnabled: true);
 
+    public static DiagnosticDescriptor UseSonarAnalyzers => New(
+        id: 1003,
+        title: "Use Sonar analyzers for packages",
+        message: "Add {0}.",
+        description: "Improve the code quality by adding Sonar's Roslyn analyzers.",
+        tags: new[] { "roslyn", "analyzer", "NuGet", "Sonar" },
+        category: Category.CodeQuality,
+        isEnabled: true);
+
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.
     private static DiagnosticDescriptor New(


### PR DESCRIPTION
# Proj1003: Use Sonar analyzers
[SonarSource](https://www.sonarsource.com/) has implemented multiple generic
Roslyn static code analysis rules both for C# and Visual Basic. These Roslyn
analyzers allow you to produce safe, reliable and maintainable code by helping
you find and correct bugs, vulnerabilities and code smells in your codebase.
It is strongly advised to enable this rules on all your projects.

See: https://github.com/SonarSource/sonar-dotnet

## Complaint
For C# projects:
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <ItemGroup Label="Analyzers">
    <ProjectReference Include="SonarAnalyzer.CSharp" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
  </ItemGroup>

</Project>
```

For VB.NET projects:
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <ItemGroup Label="Analyzers">
    <ProjectReference Include="SonarAnalyzer.VisualBasic" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
  </ItemGroup>

</Project>
```
